### PR TITLE
Fix G-Code error detection during polling

### DIFF
--- a/src/slic3r/Utils/HelioDragon.hpp
+++ b/src/slic3r/Utils/HelioDragon.hpp
@@ -85,6 +85,7 @@ public:
         int progress;
         int sizeKb;
         bool success;
+        std::vector<std::string> errors;
     };
 
     struct CreateGCodeResult


### PR DESCRIPTION
- Add errors field to PollResult structure
- Update GraphQL query to include errors field
- Parse errors from API response in poll_gcode_status()
- Check for errors during polling loop and fail early
- Verify status field exists before marking poll as successful
- Display actual API error messages instead of generic errors

Fixes issue where G-Code errors (e.g., INTERNAL_ERROR) were not detected during polling, leading to misleading error messages.