### PR TITLE
Make supported printers and materials wiki link clickable hyperlink

### DIFF
--- a/bbl/i18n/BambuStudio.pot
+++ b/bbl/i18n/BambuStudio.pot
@@ -9674,7 +9674,9 @@ msgstr ""
 msgid ""
 "Add an object to the build plate, select a material and printer that Helio supports, then slice.\n"
 "\n"
-"Supported printers: https://wiki.helioadditive.com/en/supportedprinters"
+msgstr ""
+
+msgid "Supported printers and materials"
 msgstr ""
 
 msgid "Copy PAT"

--- a/bbl/i18n/zh_CN/BambuStudio_zh_CN.po
+++ b/bbl/i18n/zh_CN/BambuStudio_zh_CN.po
@@ -9880,13 +9880,18 @@ msgid "You're nearly there! Now that Helio is activated, your first optimization
 msgstr "您快成功了！Helio 已激活，您的首次优化只需几分钟即可实现更快、更可靠的打印！（现称为\"增强\"）"
 
 msgid ""
-"Add an object to the build plate, select a material and printer that Helio supports, then slice.\n"
-"\n"
-"Supported printers: https://wiki.helioadditive.com/en/supportedprinters"
+"Add an object to the build plate, select a material and printer that Helio supports, then slice.
+"
+"
+"
 msgstr ""
-"将对象添加到打印平台，选择 Helio 支持的材料和打印机，然后切片。\n"
-"\n"
-"支持的打印机：https://wiki.helioadditive.com/en/supportedprinters"
+"将对象添加到打印平台，选择 Helio 支持的材料和打印机，然后切片。
+"
+"
+"
+
+msgid "Supported printers and materials"
+msgstr "支持的打印机和材料"
 
 msgid "Copy PAT"
 msgstr "复制 PAT"

--- a/src/slic3r/GUI/HelioReleaseNote.cpp
+++ b/src/slic3r/GUI/HelioReleaseNote.cpp
@@ -591,11 +591,18 @@ void HelioStatementDialog::create_pat_page()
         
         // Show first tutorial popup (don't open Helio dialog immediately - let user follow tutorial steps)
         if (wxGetApp().plater() && wxGetApp().plater()->get_notification_manager()) {
-            wxString tutorial_msg = _L("Add an object to the build plate, select a material and printer that Helio supports, then slice.\n\nSupported printers: https://wiki.helioadditive.com/en/supportedprinters");
+            wxString tutorial_msg = _L("Add an object to the build plate, select a material and printer that Helio supports, then slice.\n\n");
+            wxString hypertext = _L("Supported printers and materials");
+            std::string url = "https://wiki.helioadditive.com/en/supportedprinters";
             wxGetApp().plater()->get_notification_manager()->push_notification(
                 NotificationType::CustomNotification,
                 NotificationManager::NotificationLevel::HintNotificationLevel,
-                into_u8(tutorial_msg)
+                into_u8(tutorial_msg),
+                into_u8(hypertext),
+                [url](wxEvtHandler*) {
+                    wxLaunchDefaultBrowser(url);
+                    return false;
+                }
             );
         }
     });


### PR DESCRIPTION
- Changed notification to use hypertext with clickable link
- Updated text from 'Supported printers' to 'Supported printers and materials'
- Updated translations in English and Chinese