### PR TITLE
FIX: Display detailed restriction info for RESTRICTED GCode creation failures

### DIFF
--- a/src/slic3r/Utils/HelioDragon.hpp
+++ b/src/slic3r/Utils/HelioDragon.hpp
@@ -105,6 +105,7 @@ public:
         int sizeKb;
         bool success;
         std::vector<std::string> errors;
+        std::vector<std::string> restrictions;
     };
 
     struct CreateGCodeResult


### PR DESCRIPTION
Parse restrictions and restrictionsV2 fields from the gcodeV2 API response so users see the actual reason (e.g. file size too large) instead of the generic "GCode creation failed with status: RESTRICTED".