### PR TITLE
FIX: Position Helio dialogs in upper-third of parent window and fix blank space

### DIFF
--- a/src/slic3r/GUI/HelioHistoryDialog.cpp
+++ b/src/slic3r/GUI/HelioHistoryDialog.cpp
@@ -172,6 +172,17 @@ void HelioHistoryDialog::create_ui()
     SetSizer(m_main_sizer);
     Layout();
     Fit();
+    {
+        wxWindow* parent = GetParent();
+        if (parent) {
+            wxPoint parentPos = parent->GetScreenPosition();
+            wxSize parentSize = parent->GetSize();
+            wxSize dlgSize = GetSize();
+            int x = parentPos.x + (parentSize.GetWidth() - dlgSize.GetWidth()) / 2;
+            int y = parentPos.y + (parentSize.GetHeight() - dlgSize.GetHeight()) / 3;
+            SetPosition(wxPoint(x, y));
+        }
+    }
 
     BOOST_LOG_TRIVIAL(info) << "HelioHistoryDialog UI created successfully";
 }

--- a/src/slic3r/GUI/HelioReleaseNote.cpp
+++ b/src/slic3r/GUI/HelioReleaseNote.cpp
@@ -2058,7 +2058,17 @@ void HelioInputDialog::update_mode_card_styling(int selected_action)
     Layout();
     Fit();
 
-    CentreOnParent();
+    {
+        wxWindow* parent = GetParent();
+        if (parent) {
+            wxPoint parentPos = parent->GetScreenPosition();
+            wxSize parentSize = parent->GetSize();
+            wxSize dlgSize = GetSize();
+            int x = parentPos.x + (parentSize.GetWidth() - dlgSize.GetWidth()) / 2;
+            int y = parentPos.y + (parentSize.GetHeight() - dlgSize.GetHeight()) / 3;
+            SetPosition(wxPoint(x, y));
+        }
+    }
     wxGetApp().UpdateDlgDarkUI(this);
 
     /*set buy url - this is safe after main setup since it just updates an existing link*/
@@ -2968,6 +2978,17 @@ HelioPatNotEnoughDialog::HelioPatNotEnoughDialog(wxWindow* parent /*= nullptr*/)
     SetSizer(main_sizer);
     Layout();
     Fit();
+    {
+        wxWindow* parent = GetParent();
+        if (parent) {
+            wxPoint parentPos = parent->GetScreenPosition();
+            wxSize parentSize = parent->GetSize();
+            wxSize dlgSize = GetSize();
+            int x = parentPos.x + (parentSize.GetWidth() - dlgSize.GetWidth()) / 2;
+            int y = parentPos.y + (parentSize.GetHeight() - dlgSize.GetHeight()) / 3;
+            SetPosition(wxPoint(x, y));
+        }
+    }
 }
 
 HelioPatNotEnoughDialog::~HelioPatNotEnoughDialog() {}
@@ -3258,6 +3279,17 @@ HelioRatingDialog::HelioRatingDialog(wxWindow *parent, int original, int optimiz
     SetSizer(main_sizer);
     Layout();
     Fit();
+    {
+        wxWindow* parent = GetParent();
+        if (parent) {
+            wxPoint parentPos = parent->GetScreenPosition();
+            wxSize parentSize = parent->GetSize();
+            wxSize dlgSize = GetSize();
+            int x = parentPos.x + (parentSize.GetWidth() - dlgSize.GetWidth()) / 2;
+            int y = parentPos.y + (parentSize.GetHeight() - dlgSize.GetHeight()) / 3;
+            SetPosition(wxPoint(x, y));
+        }
+    }
 }
 
 void HelioRatingDialog::show_rating(std::vector<wxStaticBitmap *> stars, int rating)
@@ -3669,6 +3701,17 @@ HelioSimulationResultsDialog::HelioSimulationResultsDialog(wxWindow *parent,
     SetSizer(main_sizer);
     Layout();
     Fit();
+    {
+        wxWindow* parent = GetParent();
+        if (parent) {
+            wxPoint parentPos = parent->GetScreenPosition();
+            wxSize parentSize = parent->GetSize();
+            wxSize dlgSize = GetSize();
+            int x = parentPos.x + (parentSize.GetWidth() - dlgSize.GetWidth()) / 2;
+            int y = parentPos.y + (parentSize.GetHeight() - dlgSize.GetHeight()) / 3;
+            SetPosition(wxPoint(x, y));
+        }
+    }
 }
 
 wxString HelioSimulationResultsDialog::get_outcome_text(const HelioQuery::PrintInfo& print_info)

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10457,17 +10457,26 @@ public:
         option2_box->SetSizer(option2_sizer);
         main_sizer->Add(option2_box, 0, wxLEFT | wxRIGHT | wxBOTTOM, wxWindowBase::FromDIP(15, this));
         
-        SetSizer(main_sizer);
-        Layout();
-        main_sizer->Fit(this);
+        SetSizerAndFit(main_sizer);
+        {
+            wxWindow* parent = GetParent();
+            if (parent) {
+                wxPoint parentPos = parent->GetScreenPosition();
+                wxSize parentSize = parent->GetSize();
+                wxSize dlgSize = GetSize();
+                int x = parentPos.x + (parentSize.GetWidth() - dlgSize.GetWidth()) / 2;
+                int y = parentPos.y + (parentSize.GetHeight() - dlgSize.GetHeight()) / 3;
+                SetPosition(wxPoint(x, y));
+            }
+        }
         wxGetApp().UpdateDlgDarkUI(this);
     }
-    
+
     void on_dpi_changed(const wxRect& suggested_rect) override {}
-    
+
     int get_user_choice() const { return m_user_choice; }
     std::string get_selected_material_id() const { return m_selected_material_id; }
-    
+
 private:
     std::vector<FilamentSupportInfo> m_filaments;
     ComboBox* m_filament_combo;
@@ -10700,17 +10709,26 @@ public:
         option2_box->SetSizer(option2_sizer);
         main_sizer->Add(option2_box, 0, wxLEFT | wxRIGHT | wxBOTTOM, wxWindowBase::FromDIP(15, this));
         
-        SetSizer(main_sizer);
-        Layout();
-        main_sizer->Fit(this);
+        SetSizerAndFit(main_sizer);
+        {
+            wxWindow* parent = GetParent();
+            if (parent) {
+                wxPoint parentPos = parent->GetScreenPosition();
+                wxSize parentSize = parent->GetSize();
+                wxSize dlgSize = GetSize();
+                int x = parentPos.x + (parentSize.GetWidth() - dlgSize.GetWidth()) / 2;
+                int y = parentPos.y + (parentSize.GetHeight() - dlgSize.GetHeight()) / 3;
+                SetPosition(wxPoint(x, y));
+            }
+        }
         wxGetApp().UpdateDlgDarkUI(this);
     }
-    
+
     void on_dpi_changed(const wxRect& suggested_rect) override {}
-    
+
     int get_user_choice() const { return m_user_choice; }
     std::string get_selected_material_id() const { return m_selected_material_id; }
-    
+
 private:
     std::vector<HelioQuery::SupportedData> m_similar_materials;
     ComboBox* m_material_combo;
@@ -11540,12 +11558,21 @@ int Plater::priv::update_helio_background_process(std::string& printer_id, std::
                         option2_box->SetSizer(option2_sizer);
                         main_sizer->Add(option2_box, 0, wxLEFT | wxRIGHT | wxBOTTOM, wxWindowBase::FromDIP(15, this));
                         
-                        SetSizer(main_sizer);
-                        Layout();
-                        main_sizer->Fit(this);
+                        SetSizerAndFit(main_sizer);
+                        {
+                            wxWindow* p = GetParent();
+                            if (p) {
+                                wxPoint pp = p->GetScreenPosition();
+                                wxSize ps = p->GetSize();
+                                wxSize ds = GetSize();
+                                int x = pp.x + (ps.GetWidth() - ds.GetWidth()) / 2;
+                                int y = pp.y + (ps.GetHeight() - ds.GetHeight()) / 3;
+                                SetPosition(wxPoint(x, y));
+                            }
+                        }
                         wxGetApp().UpdateDlgDarkUI(this);
                     }
-                    
+
                     void on_dpi_changed(const wxRect &suggested_rect) override {}
                     
                 private:


### PR DESCRIPTION
- Replace SetSizer/Layout/Fit with SetSizerAndFit in HelioMixedFilamentDialog, HelioUnsupportedFilamentsDialog, and MaterialSelectionDialog to fix excess blank space caused by premature Layout() inflating wrapped label heights
- Add upper-third positioning (horizontally centered, vertically at 1/3 from top) to all Helio dialogs: HelioInputDialog, HelioHistoryDialog, HelioPatNotEnoughDialog, HelioRatingDialog, HelioSimulationResultsDialog, HelioMixedFilamentDialog, HelioUnsupportedFilamentsDialog, and MaterialSelectionDialog