### PR TITLE
Passive chamber and retry

### DIFF
--- a/src/slic3r/GUI/HelioReleaseNote.cpp
+++ b/src/slic3r/GUI/HelioReleaseNote.cpp
@@ -35,6 +35,7 @@ namespace GUI {
 #include <algorithm>
 #include <climits>
 #include <cstdlib>
+#include <boost/algorithm/string.hpp>
 #include "Plater.hpp"
 #include "BitmapCache.hpp"
 
@@ -1690,7 +1691,31 @@ void HelioInputDialog::update_mode_card_styling(int selected_action)
 
     PresetBundle* preset_bundle = wxGetApp().preset_bundle;
     auto source_model = preset_bundle->printers.get_edited_preset().get_printer_type(preset_bundle);
-    is_no_chamber = !DevPrinterConfigUtil::get_value_from_config<bool>(source_model, "print", "support_chamber");
+    std::string printer_name = preset_bundle->printers.get_edited_preset().get_printer_name(preset_bundle);
+
+    // Determine heated_chamber from Helio API (default: false)
+    bool has_heated_chamber = false;
+    if (!printer_name.empty()) {
+        std::string target_lower = boost::to_lower_copy(printer_name);
+        for (const auto& p : HelioQuery::global_supported_printers) {
+            if (p.native_name.empty()) continue;
+            std::string native_lower = boost::to_lower_copy(p.native_name);
+            if (target_lower == native_lower || target_lower.find(native_lower) != std::string::npos) {
+                has_heated_chamber = p.heated_chamber;
+                break;
+            }
+        }
+    }
+
+    // Determine if printer has any chamber (passive or heated) from local config
+    bool has_chamber = DevPrinterConfigUtil::get_value_from_config<bool>(source_model, "print", "support_chamber");
+
+    // Three states:
+    // - has_heated_chamber=true → hide temp input (backend controls)
+    // - has_chamber=true, has_heated_chamber=false → show as "Chamber Temperature"
+    // - has_chamber=false → show as "Environment Temperature"
+    is_no_chamber = !has_chamber;
+    show_temp_input = !has_heated_chamber;
 
     /*Simulation panel - wrapped in a card*/
     panel_simulation = new wxPanel(this);
@@ -1895,14 +1920,19 @@ void HelioInputDialog::update_mode_card_styling(int selected_action)
     
     wxBoxSizer* chamber_temp_item_for_optimization = nullptr;
     Label* sub_optimization = nullptr;
-    if (is_no_chamber) {
+    if (show_temp_input) {
         chamber_temp_item_for_optimization = create_input_item(card_environment, "chamber_temp_for_optimization", is_no_chamber?_L("Environment Temperature"):_L("Chamber Temperature"), wxT("\u00B0C"), {chamber_temp_checker});
         m_input_items["chamber_temp_for_optimization"]->GetTextCtrl()->SetHint(wxT("5-70"));
-        wxString temp_tooltip = _L("Refers to the environment temperature of the print (i.e. A-series - room temperature). Changing chamber temperature when running an assessment/simulation allows you to play around with different temperature scenarios.");
+        wxString temp_tooltip = is_no_chamber
+            ? _L("Refers to the environment temperature of the print (i.e. A-series - room temperature). Changing chamber temperature when running an assessment/simulation allows you to play around with different temperature scenarios.")
+            : _L("Optional. Uses the chamber temperature from Filament settings when available; you can override it here.");
         m_input_items["chamber_temp_for_optimization"]->GetTextCtrl()->SetToolTip(temp_tooltip);
         m_input_items["chamber_temp_for_optimization"]->SetToolTip(temp_tooltip);
 
-        sub_optimization = new Label(card_environment, _L("Optional. More accurate temperatures ensures better results."));
+        sub_optimization = new Label(card_environment,
+            is_no_chamber
+                ? _L("Optional. More accurate temperatures ensures better results.")
+                : _L("Optional. Uses the chamber temperature from Filament settings when available; you can override it here."));
         sub_optimization->SetForegroundColour(theme.muted);
         sub_optimization->SetSize(wxSize(FromDIP(400), -1));
         sub_optimization->Wrap(FromDIP(400));
@@ -1916,7 +1946,7 @@ void HelioInputDialog::update_mode_card_styling(int selected_action)
     
     // Layout environment card
     card_env_sizer->Add(env_header, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, FromDIP(10));
-    if (is_no_chamber && chamber_temp_item_for_optimization) {
+    if (show_temp_input && chamber_temp_item_for_optimization) {
         card_env_sizer->Add(chamber_temp_item_for_optimization, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, FromDIP(8));
     }
     card_env_sizer->Add(sub_optimization, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP | wxBOTTOM, FromDIP(10));

--- a/src/slic3r/GUI/HelioReleaseNote.cpp
+++ b/src/slic3r/GUI/HelioReleaseNote.cpp
@@ -1923,16 +1923,11 @@ void HelioInputDialog::update_mode_card_styling(int selected_action)
     if (show_temp_input) {
         chamber_temp_item_for_optimization = create_input_item(card_environment, "chamber_temp_for_optimization", is_no_chamber?_L("Environment Temperature"):_L("Chamber Temperature"), wxT("\u00B0C"), {chamber_temp_checker});
         m_input_items["chamber_temp_for_optimization"]->GetTextCtrl()->SetHint(wxT("5-70"));
-        wxString temp_tooltip = is_no_chamber
-            ? _L("Refers to the environment temperature of the print (i.e. A-series - room temperature). Changing chamber temperature when running an assessment/simulation allows you to play around with different temperature scenarios.")
-            : _L("Optional. Uses the chamber temperature from Filament settings when available; you can override it here.");
+        wxString temp_tooltip = _L("Refers to the environment temperature of the print (i.e. A-series - room temperature). Changing chamber temperature when running an assessment/simulation allows you to play around with different temperature scenarios.");
         m_input_items["chamber_temp_for_optimization"]->GetTextCtrl()->SetToolTip(temp_tooltip);
         m_input_items["chamber_temp_for_optimization"]->SetToolTip(temp_tooltip);
 
-        sub_optimization = new Label(card_environment,
-            is_no_chamber
-                ? _L("Optional. More accurate temperatures ensures better results.")
-                : _L("Optional. Uses the chamber temperature from Filament settings when available; you can override it here."));
+        sub_optimization = new Label(card_environment, _L("Optional. More accurate temperatures ensures better results."));
         sub_optimization->SetForegroundColour(theme.muted);
         sub_optimization->SetSize(wxSize(FromDIP(400), -1));
         sub_optimization->Wrap(FromDIP(400));

--- a/src/slic3r/GUI/HelioReleaseNote.hpp
+++ b/src/slic3r/GUI/HelioReleaseNote.hpp
@@ -153,6 +153,7 @@ private:
     bool use_advanced_settings{false};
     bool only_advanced_settings{false};
     bool is_no_chamber{false};
+    bool show_temp_input{false};
 
     // Mode card panels (replacing toggle buttons)
     wxPanel* simulation_card_panel{nullptr};

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -2334,10 +2334,20 @@ void MainFrame::update_slice_print_status(SlicePrintEventType event, bool can_sl
     m_slice_enable = enable_slice;
     m_print_enable = enable_print;
 
-    /*for healio*/
+    /*for helio*/
     if (expand_program_holder) {
-        expand_program_holder->updateExpandButtonBitmap(expand_helio_id, m_print_enable?"helio_icon":"helio_icon_disable");
-        expand_program_holder->EnableExpandButton(expand_helio_id, m_print_enable);
+        bool helio_enable = m_print_enable;
+        if (!helio_enable) {
+            // For non-BBL printers, the print button may be disabled due to
+            // missing print_host config, but Helio only needs valid slice results
+            bool is_bbl = wxGetApp().preset_bundle->printers.get_edited_preset().is_bbl_vendor_preset(wxGetApp().preset_bundle);
+            if (!is_bbl) {
+                PartPlate *curr_plate = m_plater->get_partplate_list().get_curr_plate();
+                helio_enable = curr_plate && curr_plate->is_slice_result_valid();
+            }
+        }
+        expand_program_holder->updateExpandButtonBitmap(expand_helio_id, helio_enable ? "helio_icon" : "helio_icon_disable");
+        expand_program_holder->EnableExpandButton(expand_helio_id, helio_enable);
     }
 
 

--- a/src/slic3r/Utils/HelioDragon.cpp
+++ b/src/slic3r/Utils/HelioDragon.cpp
@@ -1998,7 +1998,24 @@ void HelioBackgroundProcess::create_simulation_step(HelioQuery::CreateGCodeResul
         wxQueueEvent(GUI::wxGetApp().plater(), evt);
 
         const std::string gcode_id = create_gcode_res.id;
-        HelioQuery::CreateSimulationResult create_simulation_res = HelioQuery::create_simulation(helio_api_url, helio_api_key, gcode_id, simulation_input_data);
+        HelioQuery::CreateSimulationResult create_simulation_res;
+
+        const int max_create_retries = 3;
+        for (int retry = 0; retry < max_create_retries && !was_canceled(); ++retry) {
+            if (retry > 0) {
+                BOOST_LOG_TRIVIAL(warning) << "Helio: retrying create_simulation (attempt " << (retry + 1) << "/" << max_create_retries << ")";
+                boost::this_thread::sleep_for(boost::chrono::seconds(2 * retry)); // 2s, 4s backoff
+
+                Slic3r::PrintBase::SlicingStatus retry_status = Slic3r::PrintBase::SlicingStatus(15,
+                    (boost::format(_u8L("Helio: Retrying... (attempt %1%/%2%)")) % (retry + 1) % max_create_retries).str());
+                retry_status.is_helio = true;
+                Slic3r::SlicingStatusEvent* retry_evt = new Slic3r::SlicingStatusEvent(GUI::EVT_SLICING_UPDATE, 0, retry_status);
+                wxQueueEvent(GUI::wxGetApp().plater(), retry_evt);
+            }
+            create_simulation_res = HelioQuery::create_simulation(helio_api_url, helio_api_key, gcode_id, simulation_input_data);
+            if (create_simulation_res.success) break;
+        }
+
         current_simulation_result = create_simulation_res;
         current_optimization_result.reset();
         // Clear previous stored result since we're starting a new simulation
@@ -2140,7 +2157,24 @@ void HelioBackgroundProcess::create_optimization_step(HelioQuery::CreateGCodeRes
         wxQueueEvent(GUI::wxGetApp().plater(), evt);
 
         const std::string gcode_id = create_gcode_res.id;
-        HelioQuery::CreateOptimizationResult create_optimization_res = HelioQuery::create_optimization(helio_api_url, helio_api_key, gcode_id, optimization_input_data);
+        HelioQuery::CreateOptimizationResult create_optimization_res;
+
+        const int max_create_retries = 3;
+        for (int retry = 0; retry < max_create_retries && !was_canceled(); ++retry) {
+            if (retry > 0) {
+                BOOST_LOG_TRIVIAL(warning) << "Helio: retrying create_optimization (attempt " << (retry + 1) << "/" << max_create_retries << ")";
+                boost::this_thread::sleep_for(boost::chrono::seconds(2 * retry)); // 2s, 4s backoff
+
+                Slic3r::PrintBase::SlicingStatus retry_status = Slic3r::PrintBase::SlicingStatus(15,
+                    (boost::format(_u8L("Helio: Retrying... (attempt %1%/%2%)")) % (retry + 1) % max_create_retries).str());
+                retry_status.is_helio = true;
+                Slic3r::SlicingStatusEvent* retry_evt = new Slic3r::SlicingStatusEvent(GUI::EVT_SLICING_UPDATE, 0, retry_status);
+                wxQueueEvent(GUI::wxGetApp().plater(), retry_evt);
+            }
+            create_optimization_res = HelioQuery::create_optimization(helio_api_url, helio_api_key, gcode_id, optimization_input_data);
+            if (create_optimization_res.success) break;
+        }
+
         current_optimization_result = create_optimization_res;
         current_simulation_result.reset();
         // Clear previous stored result since we're starting a new optimization

--- a/src/slic3r/Utils/HelioDragon.cpp
+++ b/src/slic3r/Utils/HelioDragon.cpp
@@ -205,7 +205,7 @@ void HelioQuery::request_remaining_optimizations(const std::string & helio_api_u
 void HelioQuery::request_support_machine(const std::string helio_api_url, const std::string helio_api_key, int page, int retries_left)
 {
     std::string query_body = R"( {
-            "query": "query GetPrinters($page: Int) { printers(page: $page, pageSize: 20) { pages pageInfo { hasNextPage } objects { ... on Printer  { id name alternativeNames { bambustudio } } } } }",
+            "query": "query GetPrinters($page: Int) { printers(page: $page, pageSize: 20) { pages pageInfo { hasNextPage } objects { ... on Printer  { id name heatedChamber alternativeNames { bambustudio } } } } }",
             "variables": {"page": %1%}
 		} )";
 
@@ -238,6 +238,7 @@ void HelioQuery::request_support_machine(const std::string helio_api_url, const 
                             HelioQuery::SupportedData sp;
                             if (pobj.contains("id") && !pobj["id"].is_null()) { sp.id = pobj["id"].get<std::string>(); }
                             if (pobj.contains("name") && !pobj["id"].is_null()) { sp.name = pobj["name"].get<std::string>(); }
+                            if (pobj.contains("heatedChamber") && pobj["heatedChamber"].is_boolean()) { sp.heated_chamber = pobj["heatedChamber"].get<bool>(); }
 
                             if (pobj.contains("alternativeNames") && pobj["alternativeNames"].is_object()) {
                                 auto alternativeNames = pobj["alternativeNames"];

--- a/src/slic3r/Utils/HelioDragon.hpp
+++ b/src/slic3r/Utils/HelioDragon.hpp
@@ -90,6 +90,7 @@ public:
         std::string name;
         std::string native_name;
         std::string feedstock;
+        bool heated_chamber{false};
     };
 
     struct PrintPriorityOption {


### PR DESCRIPTION
Summary

  - Passive chamber support: X1C, P1S, and P2S have a passive (unheated) chamber. The Enhance panel now shows a "Chamber Temperature" input for these printers, using the Helio API's heatedChamber field to
  distinguish between no chamber, passive chamber, and actively heated chamber (H2S, H2D, X1E).
  - Non-BBL printer support: The Helio button is now enabled for non-BBL printers when slice results are valid, even if the print button is disabled due to missing print_host config.
  - Retry on transient errors: create_optimization() and create_simulation() now retry up to 3 times (2s/4s backoff) when they fail with transient "G-Code not found" errors caused by backend eventual consistency.
   Cancellation is respected between attempts.