### PR TITLE
🥅 Improve networking stability

### DIFF
--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -691,7 +691,7 @@ target_link_libraries(libslic3r_gui libslic3r cereal imgui imguizmo minilzo GLEW
 #target_link_libraries(libslic3r_gui libslic3r cereal imgui imguizmo minilzo GLEW::GLEW OpenGL::GL hidapi libcurl OpenSSL::SSL OpenSSL::Crypto ${wxWidgets_LIBRARIES} glfw)
 
 if (MSVC)
-    target_link_libraries(libslic3r_gui Setupapi.lib dwmapi.lib Winhttp.lib)
+    target_link_libraries(libslic3r_gui Setupapi.lib dwmapi.lib)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     FIND_LIBRARY(WAYLAND_SERVER_LIBRARIES NAMES wayland-server)
     FIND_LIBRARY(WAYLAND_EGL_LIBRARIES    NAMES wayland-egl)

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -691,7 +691,7 @@ target_link_libraries(libslic3r_gui libslic3r cereal imgui imguizmo minilzo GLEW
 #target_link_libraries(libslic3r_gui libslic3r cereal imgui imguizmo minilzo GLEW::GLEW OpenGL::GL hidapi libcurl OpenSSL::SSL OpenSSL::Crypto ${wxWidgets_LIBRARIES} glfw)
 
 if (MSVC)
-    target_link_libraries(libslic3r_gui Setupapi.lib dwmapi.lib)
+    target_link_libraries(libslic3r_gui Setupapi.lib dwmapi.lib Winhttp.lib)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     FIND_LIBRARY(WAYLAND_SERVER_LIBRARIES NAMES wayland-server)
     FIND_LIBRARY(WAYLAND_EGL_LIBRARIES    NAMES wayland-egl)

--- a/src/slic3r/GUI/NetworkTestDialog.cpp
+++ b/src/slic3r/GUI/NetworkTestDialog.cpp
@@ -10,6 +10,7 @@
 #include "GUI_App.hpp"
 #include "I18N.hpp"
 #include "slic3r/Utils/Http.hpp"
+#include "slic3r/Utils/HelioDragon.hpp"
 #include "libslic3r/AppConfig.hpp"
 #include <boost/asio/ip/address.hpp>
 #include <boost/log/trivial.hpp>
@@ -427,6 +428,30 @@ wxBoxSizer* NetworkTestDialog::create_content_sizer(wxWindow* parent)
 	text_oss_upload_title->Hide();
 	text_oss_upload_value->Hide();
 
+	btn_helio_ping = new Button(this, _L("Test Helio-Additive"));
+	btn_helio_ping->SetBackgroundColor(btn_bg);
+	grid_sizer->Add(btn_helio_ping, 0, wxEXPAND | wxALL, 5);
+
+	text_helio_ping_title = new wxStaticText(this, wxID_ANY, _L("Test Helio-Additive:"), wxDefaultPosition, wxDefaultSize, 0);
+	text_helio_ping_title->Wrap(-1);
+	grid_sizer->Add(text_helio_ping_title, 0, wxALIGN_RIGHT | wxALL, 5);
+
+	text_helio_ping_value = new wxStaticText(this, wxID_ANY, _L("N/A"), wxDefaultPosition, wxDefaultSize, 0);
+	text_helio_ping_value->Wrap(-1);
+	grid_sizer->Add(text_helio_ping_value, 0, wxALL, 5);
+
+	btn_helio_presigned = new Button(this, _L("Test Helio Presigned URL"));
+	btn_helio_presigned->SetBackgroundColor(btn_bg);
+	grid_sizer->Add(btn_helio_presigned, 0, wxEXPAND | wxALL, 5);
+
+	text_helio_presigned_title = new wxStaticText(this, wxID_ANY, _L("Test Helio Presigned URL:"), wxDefaultPosition, wxDefaultSize, 0);
+	text_helio_presigned_title->Wrap(-1);
+	grid_sizer->Add(text_helio_presigned_title, 0, wxALIGN_RIGHT | wxALL, 5);
+
+	text_helio_presigned_value = new wxStaticText(this, wxID_ANY, _L("N/A"), wxDefaultPosition, wxDefaultSize, 0);
+	text_helio_presigned_value->Wrap(-1);
+	grid_sizer->Add(text_helio_presigned_value, 0, wxALL, 5);
+
 	sizer->Add(grid_sizer, 1, wxEXPAND, 5);
 
 	btn_link->Bind(wxEVT_BUTTON, [this](wxCommandEvent& evt) {
@@ -455,6 +480,14 @@ wxBoxSizer* NetworkTestDialog::create_content_sizer(wxWindow* parent)
 
 	btn_network_plugin->Bind(wxEVT_BUTTON, [this](wxCommandEvent &evt) {
 		start_test_plugin_download_thread();
+	});
+
+	btn_helio_ping->Bind(wxEVT_BUTTON, [this](wxCommandEvent& evt) {
+		start_test_helio_ping_thread();
+	});
+
+	btn_helio_presigned->Bind(wxEVT_BUTTON, [this](wxCommandEvent& evt) {
+		start_test_helio_presigned_thread();
 	});
 
 	return sizer;
@@ -495,7 +528,11 @@ void NetworkTestDialog::init_bind()
 			text_oss_upload_value->SetLabelText(evt.GetString());
 		} else if (evt.GetInt() == TEST_PLUGIN_JOB){
 			text_network_plugin_value->SetLabelText(evt.GetString());
-        }
+        } else if (evt.GetInt() == TEST_HELIO_PING_JOB) {
+			text_helio_ping_value->SetLabelText(evt.GetString());
+		} else if (evt.GetInt() == TEST_HELIO_PRESIGNED_JOB) {
+			text_helio_presigned_value->SetLabelText(evt.GetString());
+		}
 
 		std::time_t t = std::time(0);
 		std::tm* now_time = std::localtime(&t);
@@ -551,6 +588,8 @@ void NetworkTestDialog::start_all_job()
 	start_test_oss_download_thread();
 	start_test_plugin_download_thread();
 	start_test_ping_thread();
+	start_test_helio_ping_thread();
+	start_test_helio_presigned_thread();
 }
 
 void NetworkTestDialog::start_all_job_sequence()
@@ -568,6 +607,10 @@ void NetworkTestDialog::start_all_job_sequence()
 		start_test_oss_download();
 		if (m_closing) return;
 		start_test_plugin_download();
+		if (m_closing) return;
+		start_test_helio_ping();
+		if (m_closing) return;
+		start_test_helio_presigned();
 		update_status(-1, "end_test_sequence");
 	});
 }
@@ -1066,6 +1109,98 @@ void NetworkTestDialog:: start_test_plugin_download(){
     return;
 }
 
+void NetworkTestDialog::start_test_helio_ping()
+{
+	m_in_testing[TEST_HELIO_PING_JOB] = true;
+	update_status(TEST_HELIO_PING_JOB, "test helio ping start...");
+
+	std::string url = HelioQuery::get_helio_api_url();
+	if (url.empty()) {
+		update_status(TEST_HELIO_PING_JOB, "helio api url not configured");
+		m_in_testing[TEST_HELIO_PING_JOB] = false;
+		return;
+	}
+	update_status(-1, "[test_helio_ping]: url=" + url);
+
+	Slic3r::Http http = Slic3r::Http::get(url);
+	int result = -1;
+	http.timeout_connect(10)
+		.timeout_max(15)
+		.on_ip_resolve([this](std::string ip) {
+			wxString ip_report = wxString::Format("test helio ip resolved = %s", ip);
+			update_status(TEST_HELIO_PING_JOB, ip_report);
+		})
+		.on_complete([&result](std::string body, unsigned status) {
+			if (status > 0) result = 0;
+		})
+		.on_error([this, &result](std::string body, std::string error, unsigned int status) {
+			// Any HTTP response (e.g. 400/405 on GET to GraphQL endpoint) means server reachable
+			if (status > 0) {
+				result = 0;
+			} else {
+				wxString info = wxString::Format("status=%u, body=%s, error=%s", status, body, error);
+				this->update_status(TEST_HELIO_PING_JOB, "test helio ping failed");
+				this->update_status(-1, info);
+			}
+		}).perform_sync();
+
+	if (result == 0) {
+		update_status(TEST_HELIO_PING_JOB, "test helio ping ok");
+	}
+	m_in_testing[TEST_HELIO_PING_JOB] = false;
+}
+
+void NetworkTestDialog::start_test_helio_presigned()
+{
+	m_in_testing[TEST_HELIO_PRESIGNED_JOB] = true;
+	update_status(TEST_HELIO_PRESIGNED_JOB, "test helio presigned url start...");
+
+	std::string helio_api_url = HelioQuery::get_helio_api_url();
+	std::string helio_pat     = HelioQuery::get_helio_pat();
+	if (helio_api_url.empty()) {
+		update_status(TEST_HELIO_PRESIGNED_JOB, "helio api url not configured");
+		m_in_testing[TEST_HELIO_PRESIGNED_JOB] = false;
+		return;
+	}
+	if (helio_pat.empty()) {
+		update_status(TEST_HELIO_PRESIGNED_JOB, "helio api key not set");
+		m_in_testing[TEST_HELIO_PRESIGNED_JOB] = false;
+		return;
+	}
+	update_status(-1, "[test_helio_presigned]: url=" + helio_api_url);
+
+	HelioQuery::PresignedURLResult res = HelioQuery::create_presigned_url(helio_api_url, "Bearer " + helio_pat);
+
+	if (!res.trace_id.empty()) {
+		update_status(-1, wxString::Format("[test_helio_presigned]: trace_id=%s", res.trace_id));
+	}
+
+	if (res.error.empty() && res.status == 200 && !res.url.empty()) {
+		update_status(TEST_HELIO_PRESIGNED_JOB, "test helio presigned url ok");
+	} else {
+		wxString info = wxString::Format("status=%u, error=%s", res.status, res.error);
+		update_status(TEST_HELIO_PRESIGNED_JOB, "test helio presigned url failed");
+		update_status(-1, info);
+	}
+	m_in_testing[TEST_HELIO_PRESIGNED_JOB] = false;
+}
+
+void NetworkTestDialog::start_test_helio_ping_thread()
+{
+	if (m_in_testing[TEST_HELIO_PING_JOB]) return;
+	test_job[TEST_HELIO_PING_JOB] = new boost::thread([this] {
+		start_test_helio_ping();
+	});
+}
+
+void NetworkTestDialog::start_test_helio_presigned_thread()
+{
+	if (m_in_testing[TEST_HELIO_PRESIGNED_JOB]) return;
+	test_job[TEST_HELIO_PRESIGNED_JOB] = new boost::thread([this] {
+		start_test_helio_presigned();
+	});
+}
+
 void NetworkTestDialog::start_test_ping_thread()
 {
 	test_job[TEST_PING_JOB] = new boost::thread([this] {
@@ -1173,6 +1308,8 @@ void NetworkTestDialog::set_default()
 	text_oss_download_value->SetLabelText(NA_STR);
 	text_oss_upload_value->SetLabelText(NA_STR);
 	text_network_plugin_value->SetLabelText(NA_STR);
+	text_helio_ping_value->SetLabelText(NA_STR);
+	text_helio_presigned_value->SetLabelText(NA_STR);
 	//text_ping_value->SetLabelText(NA_STR);
 	m_download_cancel = false;
 	m_closing = false;

--- a/src/slic3r/GUI/NetworkTestDialog.cpp
+++ b/src/slic3r/GUI/NetworkTestDialog.cpp
@@ -440,18 +440,6 @@ wxBoxSizer* NetworkTestDialog::create_content_sizer(wxWindow* parent)
 	text_helio_ping_value->Wrap(-1);
 	grid_sizer->Add(text_helio_ping_value, 0, wxALL, 5);
 
-	btn_helio_presigned = new Button(this, _L("Test Helio Presigned URL"));
-	btn_helio_presigned->SetBackgroundColor(btn_bg);
-	grid_sizer->Add(btn_helio_presigned, 0, wxEXPAND | wxALL, 5);
-
-	text_helio_presigned_title = new wxStaticText(this, wxID_ANY, _L("Test Helio Presigned URL:"), wxDefaultPosition, wxDefaultSize, 0);
-	text_helio_presigned_title->Wrap(-1);
-	grid_sizer->Add(text_helio_presigned_title, 0, wxALIGN_RIGHT | wxALL, 5);
-
-	text_helio_presigned_value = new wxStaticText(this, wxID_ANY, _L("N/A"), wxDefaultPosition, wxDefaultSize, 0);
-	text_helio_presigned_value->Wrap(-1);
-	grid_sizer->Add(text_helio_presigned_value, 0, wxALL, 5);
-
 	sizer->Add(grid_sizer, 1, wxEXPAND, 5);
 
 	btn_link->Bind(wxEVT_BUTTON, [this](wxCommandEvent& evt) {
@@ -484,10 +472,6 @@ wxBoxSizer* NetworkTestDialog::create_content_sizer(wxWindow* parent)
 
 	btn_helio_ping->Bind(wxEVT_BUTTON, [this](wxCommandEvent& evt) {
 		start_test_helio_ping_thread();
-	});
-
-	btn_helio_presigned->Bind(wxEVT_BUTTON, [this](wxCommandEvent& evt) {
-		start_test_helio_presigned_thread();
 	});
 
 	return sizer;
@@ -530,8 +514,6 @@ void NetworkTestDialog::init_bind()
 			text_network_plugin_value->SetLabelText(evt.GetString());
         } else if (evt.GetInt() == TEST_HELIO_PING_JOB) {
 			text_helio_ping_value->SetLabelText(evt.GetString());
-		} else if (evt.GetInt() == TEST_HELIO_PRESIGNED_JOB) {
-			text_helio_presigned_value->SetLabelText(evt.GetString());
 		}
 
 		std::time_t t = std::time(0);
@@ -589,7 +571,6 @@ void NetworkTestDialog::start_all_job()
 	start_test_plugin_download_thread();
 	start_test_ping_thread();
 	start_test_helio_ping_thread();
-	start_test_helio_presigned_thread();
 }
 
 void NetworkTestDialog::start_all_job_sequence()
@@ -609,8 +590,6 @@ void NetworkTestDialog::start_all_job_sequence()
 		start_test_plugin_download();
 		if (m_closing) return;
 		start_test_helio_ping();
-		if (m_closing) return;
-		start_test_helio_presigned();
 		update_status(-1, "end_test_sequence");
 	});
 }
@@ -1112,7 +1091,7 @@ void NetworkTestDialog:: start_test_plugin_download(){
 void NetworkTestDialog::start_test_helio_ping()
 {
 	m_in_testing[TEST_HELIO_PING_JOB] = true;
-	update_status(TEST_HELIO_PING_JOB, "test helio ping start...");
+	update_status(TEST_HELIO_PING_JOB, "test helio-additive start...");
 
 	std::string url = HelioQuery::get_helio_api_url();
 	if (url.empty()) {
@@ -1120,23 +1099,24 @@ void NetworkTestDialog::start_test_helio_ping()
 		m_in_testing[TEST_HELIO_PING_JOB] = false;
 		return;
 	}
-	update_status(-1, "[test_helio_ping]: url=" + url);
+	update_status(-1, "[test_helio_additive]: url=" + url);
 
+	// Step 1: ping the Helio API endpoint for reachability.
 	Slic3r::Http http = Slic3r::Http::get(url);
-	int result = -1;
+	int ping_result = -1;
 	http.timeout_connect(10)
 		.timeout_max(15)
 		.on_ip_resolve([this](std::string ip) {
 			wxString ip_report = wxString::Format("test helio ip resolved = %s", ip);
 			update_status(TEST_HELIO_PING_JOB, ip_report);
 		})
-		.on_complete([&result](std::string body, unsigned status) {
-			if (status > 0) result = 0;
+		.on_complete([&ping_result](std::string body, unsigned status) {
+			if (status > 0) ping_result = 0;
 		})
-		.on_error([this, &result](std::string body, std::string error, unsigned int status) {
+		.on_error([this, &ping_result](std::string body, std::string error, unsigned int status) {
 			// Any HTTP response (e.g. 400/405 on GET to GraphQL endpoint) means server reachable
 			if (status > 0) {
-				result = 0;
+				ping_result = 0;
 			} else {
 				wxString info = wxString::Format("status=%u, body=%s, error=%s", status, body, error);
 				this->update_status(TEST_HELIO_PING_JOB, "test helio ping failed");
@@ -1144,45 +1124,34 @@ void NetworkTestDialog::start_test_helio_ping()
 			}
 		}).perform_sync();
 
-	if (result == 0) {
-		update_status(TEST_HELIO_PING_JOB, "test helio ping ok");
-	}
-	m_in_testing[TEST_HELIO_PING_JOB] = false;
-}
-
-void NetworkTestDialog::start_test_helio_presigned()
-{
-	m_in_testing[TEST_HELIO_PRESIGNED_JOB] = true;
-	update_status(TEST_HELIO_PRESIGNED_JOB, "test helio presigned url start...");
-
-	std::string helio_api_url = HelioQuery::get_helio_api_url();
-	std::string helio_pat     = HelioQuery::get_helio_pat();
-	if (helio_api_url.empty()) {
-		update_status(TEST_HELIO_PRESIGNED_JOB, "helio api url not configured");
-		m_in_testing[TEST_HELIO_PRESIGNED_JOB] = false;
+	if (ping_result != 0) {
+		m_in_testing[TEST_HELIO_PING_JOB] = false;
 		return;
 	}
+	update_status(TEST_HELIO_PING_JOB, "test helio ping ok");
+
+	// Step 2: verify presigned-URL creation (requires PAT).
+	std::string helio_pat = HelioQuery::get_helio_pat();
 	if (helio_pat.empty()) {
-		update_status(TEST_HELIO_PRESIGNED_JOB, "helio api key not set");
-		m_in_testing[TEST_HELIO_PRESIGNED_JOB] = false;
+		update_status(TEST_HELIO_PING_JOB, "helio ping ok; api key not set (presigned skipped)");
+		m_in_testing[TEST_HELIO_PING_JOB] = false;
 		return;
 	}
-	update_status(-1, "[test_helio_presigned]: url=" + helio_api_url);
 
-	HelioQuery::PresignedURLResult res = HelioQuery::create_presigned_url(helio_api_url, "Bearer " + helio_pat);
+	HelioQuery::PresignedURLResult res = HelioQuery::create_presigned_url(url, "Bearer " + helio_pat);
 
 	if (!res.trace_id.empty()) {
-		update_status(-1, wxString::Format("[test_helio_presigned]: trace_id=%s", res.trace_id));
+		update_status(-1, wxString::Format("[test_helio_additive]: trace_id=%s", res.trace_id));
 	}
 
 	if (res.error.empty() && res.status == 200 && !res.url.empty()) {
-		update_status(TEST_HELIO_PRESIGNED_JOB, "test helio presigned url ok");
+		update_status(TEST_HELIO_PING_JOB, "test helio-additive ok");
 	} else {
 		wxString info = wxString::Format("status=%u, error=%s", res.status, res.error);
-		update_status(TEST_HELIO_PRESIGNED_JOB, "test helio presigned url failed");
+		update_status(TEST_HELIO_PING_JOB, "test helio presigned url failed");
 		update_status(-1, info);
 	}
-	m_in_testing[TEST_HELIO_PRESIGNED_JOB] = false;
+	m_in_testing[TEST_HELIO_PING_JOB] = false;
 }
 
 void NetworkTestDialog::start_test_helio_ping_thread()
@@ -1190,14 +1159,6 @@ void NetworkTestDialog::start_test_helio_ping_thread()
 	if (m_in_testing[TEST_HELIO_PING_JOB]) return;
 	test_job[TEST_HELIO_PING_JOB] = new boost::thread([this] {
 		start_test_helio_ping();
-	});
-}
-
-void NetworkTestDialog::start_test_helio_presigned_thread()
-{
-	if (m_in_testing[TEST_HELIO_PRESIGNED_JOB]) return;
-	test_job[TEST_HELIO_PRESIGNED_JOB] = new boost::thread([this] {
-		start_test_helio_presigned();
 	});
 }
 
@@ -1309,7 +1270,6 @@ void NetworkTestDialog::set_default()
 	text_oss_upload_value->SetLabelText(NA_STR);
 	text_network_plugin_value->SetLabelText(NA_STR);
 	text_helio_ping_value->SetLabelText(NA_STR);
-	text_helio_presigned_value->SetLabelText(NA_STR);
 	//text_ping_value->SetLabelText(NA_STR);
 	m_download_cancel = false;
 	m_closing = false;

--- a/src/slic3r/GUI/NetworkTestDialog.cpp
+++ b/src/slic3r/GUI/NetworkTestDialog.cpp
@@ -259,13 +259,15 @@ wxBoxSizer* NetworkTestDialog::create_top_sizer(wxWindow* parent)
 	btn_download_log = new Button(this, _L("Export Log"));
     btn_download_log->SetBackgroundColor(btn_bg);
 	line_sizer->Add(btn_download_log, 0, wxALL, 5);
-	btn_download_log->Hide();
 
 	btn_start->Bind(wxEVT_BUTTON, [this](wxCommandEvent &evt) {
 			start_all_job();
 		});
 	btn_start_sequence->Bind(wxEVT_BUTTON, [this](wxCommandEvent &evt) {
 			start_all_job_sequence();
+		});
+	btn_download_log->Bind(wxEVT_BUTTON, [](wxCommandEvent&) {
+			desktop_open_any_folder(data_dir() + "/log");
 		});
 	sizer->Add(line_sizer, 0, wxEXPAND, 5);
 	return sizer;

--- a/src/slic3r/GUI/NetworkTestDialog.hpp
+++ b/src/slic3r/GUI/NetworkTestDialog.hpp
@@ -44,8 +44,7 @@ enum TestJob {
 	TEST_PING_JOB = 7,
 	TEST_PLUGIN_JOB = 8,
 	TEST_HELIO_PING_JOB = 9,
-	TEST_HELIO_PRESIGNED_JOB = 10,
-	TEST_JOB_MAX = 11
+	TEST_JOB_MAX = 10
 };
 
 class NetworkTestDialog : public DPIDialog
@@ -90,9 +89,6 @@ protected:
 	Button*     btn_helio_ping;
 	wxStaticText* text_helio_ping_title;
 	wxStaticText* text_helio_ping_value;
-	Button*     btn_helio_presigned;
-	wxStaticText* text_helio_presigned_title;
-	wxStaticText* text_helio_presigned_value;
 	wxStaticText* text_result;
 	wxTextCtrl* txt_log;
 
@@ -133,7 +129,6 @@ public:
 	void start_test_ping_thread();
 	void start_test_plugin_download_thread();
 	void start_test_helio_ping_thread();
-	void start_test_helio_presigned_thread();
 
 	void start_test_bing();
 	void start_test_bambulab();
@@ -144,7 +139,6 @@ public:
 	void start_test_oss_upload();
 	void start_test_plugin_download();
 	void start_test_helio_ping();
-	void start_test_helio_presigned();
 
 	void on_close(wxCloseEvent& event);
 

--- a/src/slic3r/GUI/NetworkTestDialog.hpp
+++ b/src/slic3r/GUI/NetworkTestDialog.hpp
@@ -43,7 +43,9 @@ enum TestJob {
 	TEST_OSS_UPLOAD_JOB = 6,
 	TEST_PING_JOB = 7,
 	TEST_PLUGIN_JOB = 8,
-	TEST_JOB_MAX = 9
+	TEST_HELIO_PING_JOB = 9,
+	TEST_HELIO_PRESIGNED_JOB = 10,
+	TEST_JOB_MAX = 11
 };
 
 class NetworkTestDialog : public DPIDialog
@@ -85,6 +87,12 @@ protected:
 	wxStaticText* text_network_plugin_value;
 	wxStaticText* text_ping_title;
 	wxStaticText* text_ping_value;
+	Button*     btn_helio_ping;
+	wxStaticText* text_helio_ping_title;
+	wxStaticText* text_helio_ping_value;
+	Button*     btn_helio_presigned;
+	wxStaticText* text_helio_presigned_title;
+	wxStaticText* text_helio_presigned_value;
 	wxStaticText* text_result;
 	wxTextCtrl* txt_log;
 
@@ -124,6 +132,8 @@ public:
 	void start_test_oss_upload_thread();
 	void start_test_ping_thread();
 	void start_test_plugin_download_thread();
+	void start_test_helio_ping_thread();
+	void start_test_helio_presigned_thread();
 
 	void start_test_bing();
 	void start_test_bambulab();
@@ -133,6 +143,8 @@ public:
 	void start_test_oss_download();
 	void start_test_oss_upload();
 	void start_test_plugin_download();
+	void start_test_helio_ping();
+	void start_test_helio_presigned();
 
 	void on_close(wxCloseEvent& event);
 

--- a/src/slic3r/Utils/HelioDragon.cpp
+++ b/src/slic3r/Utils/HelioDragon.cpp
@@ -50,7 +50,13 @@ void helio_log_write(const std::string& msg, bool is_error)
     const auto now = std::chrono::system_clock::now();
     const auto t   = std::chrono::system_clock::to_time_t(now);
     char ts[24];
-    std::strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%SZ", std::gmtime(&t));
+    struct tm tm_buf{};
+#if defined(_WIN32)
+    gmtime_s(&tm_buf, &t);
+#else
+    gmtime_r(&t, &tm_buf);
+#endif
+    std::strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%SZ", &tm_buf);
     f << ts << (is_error ? " [ERR] " : " [INF] ") << msg << "\n";
 }
 
@@ -177,11 +183,13 @@ void HelioQuery::request_remaining_optimizations(const std::string & helio_api_u
         .set_post_body(query_body);
 
     HelioLogLine(false) << "Helio → request_remaining_optimizations " << url_copy;
+    const auto req_start = std::chrono::steady_clock::now();
     http.timeout_connect(20)
         .timeout_max(100)
         .retries(2)
-        .on_complete([url_copy, key_copy, func](std::string body, unsigned status) {
-        HelioLogLine(false) << "Helio ← request_remaining_optimizations status=" << status;
+        .on_complete([url_copy, key_copy, func, req_start](std::string body, unsigned status) {
+        const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
+        HelioLogLine(false) << "Helio ← request_remaining_optimizations status=" << status << " duration=" << req_ms << "ms";
         try {
             nlohmann::json parsed_obj = nlohmann::json::parse(body);
 
@@ -243,9 +251,10 @@ void HelioQuery::request_remaining_optimizations(const std::string & helio_api_u
             func(0, 0, "", false, false, false);
         }
             })
-        .on_error([func](std::string body, std::string error, unsigned status) {
+        .on_error([func, req_start](std::string body, std::string error, unsigned status) {
+            const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
+            HelioLogLine(true) << "Helio request_remaining_optimizations error: " << error << " status=" << status << " duration=" << req_ms << "ms" << " body=" << body.substr(0, 300);
             func(0, 0, "", false, false, false);
-            BOOST_LOG_TRIVIAL(error) << "Failed to obtain remaining optimization attempts: " << error << ", status: " << status;
         })
         .perform();
 }
@@ -273,9 +282,12 @@ void HelioQuery::request_support_machine(const std::string helio_api_url, const 
         .set_post_body(query_body);
 
     HelioLogLine(false) << "Helio → request_support_machine page=" << page_copy << " " << url_copy;
+    const auto req_start = std::chrono::steady_clock::now();
     http.timeout_connect(20)
         .timeout_max(100)
-        .on_complete([url_copy, key_copy, page_copy, retries_left](std::string body, unsigned status) {
+        .on_complete([url_copy, key_copy, page_copy, retries_left, req_start](std::string body, unsigned status) {
+            const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
+            HelioLogLine(false) << "Helio ← request_support_machine page=" << page_copy << " status=" << status << " duration=" << req_ms << "ms";
             nlohmann::json                         parsed_obj = nlohmann::json::parse(body);
             std::vector<HelioQuery::SupportedData> supported_printers;
 
@@ -328,8 +340,9 @@ void HelioQuery::request_support_machine(const std::string helio_api_url, const 
                 }
             }
         })
-        .on_error([url_copy, key_copy, page_copy, retries_left](std::string body, std::string error, unsigned status) {
-            BOOST_LOG_TRIVIAL(error) << "request_support_machine error (page " << page_copy << ", retries=" << retries_left << "): " << error << ", status: " << status << ", body: " << body;
+        .on_error([url_copy, key_copy, page_copy, retries_left, req_start](std::string body, std::string error, unsigned status) {
+            const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
+            HelioLogLine(true) << "Helio request_support_machine error (page " << page_copy << ", retries=" << retries_left << "): " << error << " status=" << status << " duration=" << req_ms << "ms" << " body=" << body.substr(0, 300);
             if (retries_left > 0) {
                 std::this_thread::sleep_for(std::chrono::seconds(2));
                 HelioQuery::request_support_machine(url_copy, key_copy, page_copy, retries_left - 1);
@@ -362,10 +375,12 @@ void HelioQuery::request_support_material(const std::string helio_api_url, const
         .set_post_body(query_body);
 
     HelioLogLine(false) << "Helio → request_support_material page=" << page_copy << " " << url_copy;
+    const auto req_start = std::chrono::steady_clock::now();
     http.timeout_connect(20)
         .timeout_max(100)
-        .on_complete([url_copy, key_copy, page_copy, retries_left](std::string body, unsigned status) {
-            HelioLogLine(false) << "Helio ← request_support_material page=" << page_copy << " status=" << status;
+        .on_complete([url_copy, key_copy, page_copy, retries_left, req_start](std::string body, unsigned status) {
+            const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
+            HelioLogLine(false) << "Helio ← request_support_material page=" << page_copy << " status=" << status << " duration=" << req_ms << "ms";
             nlohmann::json                         parsed_obj = nlohmann::json::parse(body);
             std::vector<HelioQuery::SupportedData> supported_materials;
 
@@ -424,8 +439,9 @@ void HelioQuery::request_support_material(const std::string helio_api_url, const
                 }
             }
         })
-        .on_error([url_copy, key_copy, page_copy, retries_left](std::string body, std::string error, unsigned status) {
-            BOOST_LOG_TRIVIAL(error) << "request_support_material error (page " << page_copy << ", retries=" << retries_left << "): " << error << ", status: " << status << ", body: " << body;
+        .on_error([url_copy, key_copy, page_copy, retries_left, req_start](std::string body, std::string error, unsigned status) {
+            const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
+            HelioLogLine(true) << "Helio request_support_material error (page " << page_copy << ", retries=" << retries_left << "): " << error << " status=" << status << " duration=" << req_ms << "ms" << " body=" << body.substr(0, 300);
             if (retries_left > 0) {
                 std::this_thread::sleep_for(std::chrono::seconds(2));
                 HelioQuery::request_support_material(url_copy, key_copy, page_copy, retries_left - 1);
@@ -466,15 +482,18 @@ void HelioQuery::request_print_priority_options(
 
     http.set_post_body(query_body);
 
-    HelioLogLine(false) << "Helio → request_print_priority_options material=" << material_id;
+    HelioLogLine(false) << "Helio → request_print_priority_options material=" << material_id << " url=" << helio_api_url;
     auto response_headers = std::make_shared<std::string>();
+    const auto req_start = std::chrono::steady_clock::now();
     http.timeout_connect(10)
         .timeout_max(30)
         .retries(2)
         .on_header_callback([response_headers](std::string headers) {
             *response_headers += headers;
         })
-        .on_complete([callback, material_id, response_headers](std::string body, unsigned status) {
+        .on_complete([callback, material_id, response_headers, req_start](std::string body, unsigned status) {
+            const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
+            HelioLogLine(false) << "Helio ← request_print_priority_options status=" << status << " duration=" << req_ms << "ms";
             BOOST_LOG_TRIVIAL(info) << "request_print_priority_options response: " << body;
 
             GetPrintPriorityOptionsResult result;
@@ -526,9 +545,9 @@ void HelioQuery::request_print_priority_options(
 
             callback(result);
         })
-        .on_error([callback, response_headers](std::string body, std::string error, unsigned status) {
-            BOOST_LOG_TRIVIAL(error) << "request_print_priority_options error: " << error
-                                    << ", status: " << status << ", body: " << body;
+        .on_error([callback, response_headers, req_start](std::string body, std::string error, unsigned status) {
+            const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
+            HelioLogLine(true) << "Helio request_print_priority_options error: " << error << " status=" << status << " duration=" << req_ms << "ms" << " body=" << body.substr(0, 300);
             GetPrintPriorityOptionsResult result;
             result.success = false;
             result.error = error;
@@ -602,11 +621,13 @@ void HelioQuery::request_pat_token(std::function<void(std::string)> func)
     // logic and propagated to on_error, where we translate it to "not_enough".
     HelioLogLine(false) << "Helio → request_pat_token " << url_copy;
     auto http = Http::get(url_copy);
+    const auto req_start = std::chrono::steady_clock::now();
     http.timeout_connect(20)
         .timeout_max(100)
         .retries(3)
-        .on_complete([func](std::string body, unsigned status) {
-            HelioLogLine(false) << "Helio ← request_pat_token status=" << status;
+        .on_complete([func, req_start](std::string body, unsigned status) {
+            const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
+            HelioLogLine(false) << "Helio ← request_pat_token status=" << status << " duration=" << req_ms << "ms";
             if (status == 200) {
                 try {
                     nlohmann::json parsed_obj = nlohmann::json::parse(body);
@@ -628,9 +649,10 @@ void HelioQuery::request_pat_token(std::function<void(std::string)> func)
                 func("error");
             }
         })
-        .on_error([func](std::string body, std::string error, unsigned status) {
+        .on_error([func, req_start](std::string body, std::string error, unsigned status) {
+            const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
             HelioLogLine(true) << "Helio request_pat_token error: "
-                                     << error << ", status: " << status;
+                                     << error << ", status: " << status << " duration=" << req_ms << "ms" << " body=" << body.substr(0, 300);
             if (status == 429) {
                 func("not_enough");
             } else {
@@ -666,7 +688,8 @@ void HelioQuery::optimization_feedback(const std::string helio_api_url, const st
         .header("HelioAdditive-Client-Version", GUI::VersionInfo::convert_full_version(SLIC3R_VERSION))
         .set_post_body(query_body);
 
-    HelioLogLine(false) << "Helio → optimization_feedback opt_id=" << optimization_id;
+    HelioLogLine(false) << "Helio → optimization_feedback opt_id=" << optimization_id << " url=" << helio_api_url << " rating=" << rating;
+    const auto req_start = std::chrono::steady_clock::now();
     http.timeout_connect(20)
         .timeout_max(100)
         // One retry only — feedback is a POST and the server has no idempotency key,
@@ -674,13 +697,13 @@ void HelioQuery::optimization_feedback(const std::string helio_api_url, const st
         // errors (the Windows failure mode) are safe because nothing reached the server.
         .retries(1)
         .on_complete([=](std::string body, unsigned status) {
+            const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
+            HelioLogLine(false) << "Helio ← optimization_feedback status=" << status << " duration=" << req_ms << "ms";
             BOOST_LOG_TRIVIAL(info) << "optimization_feedback response: " << body << ", status: " << status;
         })
         .on_error([=](std::string body, std::string error, unsigned status) {
-            BOOST_LOG_TRIVIAL(error) << "optimization_feedback error: " << error
-                                     << ", status: " << status
-                                     << ", body: " << body
-                                     << ", optimization_id: " << optimization_id;
+            const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
+            HelioLogLine(true) << "Helio optimization_feedback error: " << error << " status=" << status << " duration=" << req_ms << "ms" << " body=" << body.substr(0, 300);
         })
         .perform();
 }
@@ -708,6 +731,7 @@ HelioQuery::PresignedURLResult HelioQuery::create_presigned_url(const std::strin
     }
 
     HelioLogLine(false) << "Helio → create_presigned_url " << helio_api_url;
+    const auto req_start = std::chrono::steady_clock::now();
     http.timeout_connect(20)
         .timeout_max(100)
         // create_presigned_url returns an S3 upload URL. Duplicate URLs from a retry
@@ -723,23 +747,25 @@ HelioQuery::PresignedURLResult HelioQuery::create_presigned_url(const std::strin
                 res.trace_id = trace_id;
             }
         })
-        .on_complete([&res](std::string body, unsigned status) {
+        .on_complete([&res, &req_start](std::string body, unsigned status) {
+            const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
             res.status = status;
             nlohmann::json parsed_obj = nlohmann::json::parse(body);
             if (parsed_obj.contains("error")) {
                 res.error = parsed_obj["error"];
-                HelioLogLine(true) << "Helio ← create_presigned_url status=" << status << " error=" << res.error << " trace=" << res.trace_id;
+                HelioLogLine(true) << "Helio ← create_presigned_url status=" << status << " error=" << res.error << " trace=" << res.trace_id << " duration=" << req_ms << "ms";
             } else {
                 res.key      = parsed_obj["data"]["getPresignedUrl"]["key"];
                 res.mimeType = parsed_obj["data"]["getPresignedUrl"]["mimeType"];
                 res.url      = parsed_obj["data"]["getPresignedUrl"]["url"];
-                HelioLogLine(false) << "Helio ← create_presigned_url status=" << status << " key=" << res.key << " trace=" << res.trace_id;
+                HelioLogLine(false) << "Helio ← create_presigned_url status=" << status << " key=" << res.key << " trace=" << res.trace_id << " duration=" << req_ms << "ms";
             }
         })
-        .on_error([&res](std::string body, std::string error, unsigned status) {
+        .on_error([&res, &req_start](std::string body, std::string error, unsigned status) {
+            const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
             res.error  = (boost::format("error: %1%, message: %2%") % error % body).str();
             res.status = status;
-            HelioLogLine(true) << "Helio create_presigned_url error: " << error << " status=" << status;
+            HelioLogLine(true) << "Helio create_presigned_url error: " << error << " status=" << status << " duration=" << req_ms << "ms";
         })
         .perform_sync();
 
@@ -771,7 +797,10 @@ HelioQuery::UploadFileResult HelioQuery::upload_file_to_presigned_url(const std:
         HelioLogLine(true) << "Helio upload_file check original: unknown error";
     }
 
-    HelioLogLine(false) << "Helio → upload_file_to_presigned_url file=" << file_path.filename().string();
+    uintmax_t file_sz = 0;
+    try { file_sz = boost::filesystem::file_size(file_path); } catch (...) {}
+    HelioLogLine(false) << "Helio → upload_file_to_presigned_url file=" << file_path.filename().string() << " size=" << file_sz << "B";
+    const auto req_start = std::chrono::steady_clock::now();
     http.set_put_body(file_path)
         // S3 PUT against a presigned URL is idempotent: the second PUT just overwrites
         // the first. Two retries gives us resilience for the upload step without
@@ -787,17 +816,19 @@ HelioQuery::UploadFileResult HelioQuery::upload_file_to_presigned_url(const std:
                 res.trace_id = trace_id;
             }
         })
-        .on_complete([&res](std::string body, unsigned status) {
+        .on_complete([&res, &req_start](std::string body, unsigned status) {
+            const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
             if (status == 200)
                 res.success = true;
             else
                 res.success = false;
-            HelioLogLine(false) << "Helio ← upload_file_to_presigned_url status=" << status << " success=" << res.success;
+            HelioLogLine(false) << "Helio ← upload_file_to_presigned_url status=" << status << " success=" << res.success << " duration=" << req_ms << "ms";
         })
-        .on_error([&res](std::string body, std::string error, unsigned status) {
+        .on_error([&res, &req_start](std::string body, std::string error, unsigned status) {
+            const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
             res.success = false;
             res.error   = (boost::format("status: %1%, error: %2%, %3%") % status % body % error).str();
-            HelioLogLine(true) << "Helio upload_file_to_presigned_url error: " << error << " status=" << status;
+            HelioLogLine(true) << "Helio upload_file_to_presigned_url error: " << error << " status=" << status << " duration=" << req_ms << "ms";
         })
         .perform_sync();
 
@@ -818,6 +849,7 @@ HelioQuery::PollResult HelioQuery::poll_gcode_status(const std::string& helio_ap
     std::string poll_body = (boost::format(poll_query) % gcode_id).str();
 
     BOOST_LOG_TRIVIAL(debug) << "Helio → poll_gcode_status id=" << gcode_id;
+    const auto req_start = std::chrono::steady_clock::now();
     auto poll_http = Http::post(helio_api_url);
     poll_http.header("Content-Type", "application/json")
         .header("Authorization", helio_api_key)
@@ -916,8 +948,9 @@ HelioQuery::PollResult HelioQuery::poll_gcode_status(const std::string& helio_ap
                 HelioLogLine(true) << "Helio poll_gcode_status: unknown error";
             }
         })
-        .on_error([&result](std::string poll_body, std::string poll_error, unsigned poll_status) {
-            HelioLogLine(true) << "Helio poll_gcode_status error: " << poll_error << ", status: " << poll_status;
+        .on_error([&result, &req_start](std::string poll_body, std::string poll_error, unsigned poll_status) {
+            const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
+            HelioLogLine(true) << "Helio poll_gcode_status error: " << poll_error << " status=" << poll_status << " duration=" << req_ms << "ms" << " body=" << poll_body.substr(0, 300);
         })
         .perform_sync();
 
@@ -962,7 +995,8 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode(const std::string key,
         http.header("Accept-Language", "zh-CN");
     }
 
-    HelioLogLine(false) << "Helio → create_gcode_v2 printer=" << printer_id << " filament=" << filament_id;
+    HelioLogLine(false) << "Helio → create_gcode_v2 printer=" << printer_id << " filament=" << filament_id << " url=" << helio_api_url;
+    const auto req_start = std::chrono::steady_clock::now();
     http.timeout_connect(20)
         .timeout_max(100)
         .on_header_callback([&res](std::string header_line) {
@@ -975,7 +1009,8 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode(const std::string key,
                 res.trace_id = trace_id;
             }
         })
-        .on_complete([&res, helio_api_url, helio_api_key](std::string body, unsigned status) {
+        .on_complete([&res, &req_start, helio_api_url, helio_api_key](std::string body, unsigned status) {
+        const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
         res.status = status;
         try {
             json parsed_obj = json::parse(body);
@@ -983,7 +1018,7 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode(const std::string key,
                 std::string message = format_error(body);
                 res.error = message;
                 res.success = false;
-                HelioLogLine(true) << "Helio ← create_gcode_v2 status=" << status << " error=" << message << " trace=" << res.trace_id;
+                HelioLogLine(true) << "Helio ← create_gcode_v2 status=" << status << " error=" << message << " trace=" << res.trace_id << " duration=" << req_ms << "ms";
                 return;
             }
 
@@ -1000,7 +1035,7 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode(const std::string key,
             res.sizeKb = gcode["sizeKb"];
             res.status_str = gcode["status"];
             res.progress = gcode["progress"];
-            HelioLogLine(false) << "Helio ← create_gcode_v2 status=" << status << " id=" << res.id << " trace=" << res.trace_id;
+            HelioLogLine(false) << "Helio ← create_gcode_v2 status=" << status << " id=" << res.id << " trace=" << res.trace_id << " duration=" << req_ms << "ms";
 
             // Check for errors in initial response
             if (gcode.contains("errors") && !gcode["errors"].is_null()) {
@@ -1042,8 +1077,6 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode(const std::string key,
             int consecutive_failures = 0;
 
             while (res.status_str != "READY" && res.status_str != "ERROR" && res.status_str != "RESTRICTED") {
-                std::this_thread::sleep_for(std::chrono::seconds(2));
-
                 const auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
                                          std::chrono::steady_clock::now() - poll_start)
                                          .count();
@@ -1055,6 +1088,7 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode(const std::string key,
                     return;
                 }
 
+                std::this_thread::sleep_for(std::chrono::seconds(2));
                 PollResult poll_res = poll_gcode_status(helio_api_url, helio_api_key, res.id);
 
                 if (!poll_res.success) {
@@ -1114,11 +1148,12 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode(const std::string key,
             res.error = _u8L("Failed to parse response");
         }
         })
-        .on_error([&res](std::string body, std::string error, unsigned status) {
+        .on_error([&res, &req_start](std::string body, std::string error, unsigned status) {
+            const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
             res.success = false;
             res.error  = error;
             res.status = status;
-            HelioLogLine(true) << "Helio create_gcode_v2 error: " << error << " status=" << status;
+            HelioLogLine(true) << "Helio create_gcode_v2 error: " << error << " status=" << status << " duration=" << req_ms << "ms" << " body=" << body.substr(0, 300);
         })
         .perform_sync();
 
@@ -1178,7 +1213,8 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode_v3(const std::string key,
         http.header("Accept-Language", "zh-CN");
     }
 
-    HelioLogLine(false) << "Helio → create_gcode_v3 printer=" << printer_id;
+    HelioLogLine(false) << "Helio → create_gcode_v3 printer=" << printer_id << " url=" << helio_api_url;
+    const auto req_start = std::chrono::steady_clock::now();
     http.timeout_connect(20)
         .timeout_max(100)
         .on_header_callback([&res](std::string header_line) {
@@ -1191,7 +1227,8 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode_v3(const std::string key,
                 res.trace_id = trace_id;
             }
         })
-        .on_complete([&res, helio_api_url, helio_api_key](std::string body, unsigned status) {
+        .on_complete([&res, &req_start, helio_api_url, helio_api_key](std::string body, unsigned status) {
+        const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
         res.status = status;
         try {
             json parsed_obj = json::parse(body);
@@ -1199,7 +1236,7 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode_v3(const std::string key,
                 std::string message = format_error(body);
                 res.error = message;
                 res.success = false;
-                HelioLogLine(true) << "Helio ← create_gcode_v3 status=" << status << " error=" << message << " trace=" << res.trace_id;
+                HelioLogLine(true) << "Helio ← create_gcode_v3 status=" << status << " error=" << message << " trace=" << res.trace_id << " duration=" << req_ms << "ms";
                 return;
             }
 
@@ -1216,7 +1253,7 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode_v3(const std::string key,
             res.sizeKb = gcode["sizeKb"];
             res.status_str = gcode["status"];
             res.progress = gcode["progress"];
-            HelioLogLine(false) << "Helio ← create_gcode_v3 status=" << status << " id=" << res.id << " trace=" << res.trace_id;
+            HelioLogLine(false) << "Helio ← create_gcode_v3 status=" << status << " id=" << res.id << " trace=" << res.trace_id << " duration=" << req_ms << "ms";
 
             // Check for errors in initial response
             if (gcode.contains("errors") && !gcode["errors"].is_null()) {
@@ -1252,8 +1289,6 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode_v3(const std::string key,
             int consecutive_failures = 0;
 
             while (res.status_str != "READY" && res.status_str != "ERROR" && res.status_str != "RESTRICTED") {
-                std::this_thread::sleep_for(std::chrono::seconds(2));
-
                 const auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
                                          std::chrono::steady_clock::now() - poll_start)
                                          .count();
@@ -1265,6 +1300,7 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode_v3(const std::string key,
                     return;
                 }
 
+                std::this_thread::sleep_for(std::chrono::seconds(2));
                 PollResult poll_res = poll_gcode_status(helio_api_url, helio_api_key, res.id);
 
                 if (!poll_res.success) {
@@ -1329,11 +1365,12 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode_v3(const std::string key,
             res.error = _u8L("Failed to parse response");
         }
         })
-        .on_error([&res](std::string body, std::string error, unsigned status) {
+        .on_error([&res, &req_start](std::string body, std::string error, unsigned status) {
+            const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
             res.success = false;
             res.error  = error;
             res.status = status;
-            HelioLogLine(true) << "Helio create_gcode_v3 error: " << error << " status=" << status;
+            HelioLogLine(true) << "Helio create_gcode_v3 error: " << error << " status=" << status << " duration=" << req_ms << "ms" << " body=" << body.substr(0, 300);
         })
         .perform_sync();
 
@@ -1501,7 +1538,8 @@ std::string HelioQuery::create_optimization_default_get(const std::string helio_
         .header("HelioAdditive-Client-Version", GUI::VersionInfo::convert_full_version(SLIC3R_VERSION))
         .set_post_body(query_body);
 
-    HelioLogLine(false) << "Helio → create_optimization_default_get gcode_id=" << gcode_id;
+    HelioLogLine(false) << "Helio → create_optimization_default_get gcode_id=" << gcode_id << " url=" << helio_api_url;
+    const auto req_start = std::chrono::steady_clock::now();
     std::string response_headers;
     http.timeout_connect(20)
         .timeout_max(100)
@@ -1509,12 +1547,14 @@ std::string HelioQuery::create_optimization_default_get(const std::string helio_
         .on_header_callback([&response_headers](std::string headers) {
             response_headers += headers;
         })
-        .on_complete([&res](std::string body, unsigned status) {
-            HelioLogLine(false) << "Helio ← create_optimization_default_get status=" << status;
+        .on_complete([&res, &req_start](std::string body, unsigned status) {
+            const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
+            HelioLogLine(false) << "Helio ← create_optimization_default_get status=" << status << " duration=" << req_ms << "ms";
             nlohmann::json parsed_obj = nlohmann::json::parse(body);
         })
-        .on_error([&res, &response_headers](std::string body, std::string error, unsigned status) {
-            HelioLogLine(true) << "Helio create_optimization_default_get error: " << error << ", status: " << status;
+        .on_error([&res, &response_headers, &req_start](std::string body, std::string error, unsigned status) {
+            const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
+            HelioLogLine(true) << "Helio create_optimization_default_get error: " << error << " status=" << status << " duration=" << req_ms << "ms";
         })
         .perform_sync();
 
@@ -1561,29 +1601,32 @@ HelioQuery::CreateSimulationResult HelioQuery::create_simulation(const std::stri
         http.header("Accept-Language", "zh-CN");
     }
 
-    HelioLogLine(false) << "Helio → create_simulation gcode_id=" << gcode_id;
+    HelioLogLine(false) << "Helio → create_simulation gcode_id=" << gcode_id << " url=" << helio_api_url;
+    const auto req_start = std::chrono::steady_clock::now();
     http.timeout_connect(20)
         .timeout_max(100)
-        .on_complete([&res](std::string body, unsigned status) {
+        .on_complete([&res, &req_start](std::string body, unsigned status) {
+            const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
             nlohmann::json parsed_obj = nlohmann::json::parse(body);
             res.status                = status;
             if (parsed_obj.contains("errors")) {
                 std::string message = format_error(body);
                 res.error   = message;
                 res.success = false;
-                HelioLogLine(true) << "Helio ← create_simulation status=" << status << " error=" << message << " trace=" << res.trace_id;
+                HelioLogLine(true) << "Helio ← create_simulation status=" << status << " error=" << message << " trace=" << res.trace_id << " duration=" << req_ms << "ms";
             } else {
                 res.success = true;
                 res.id      = parsed_obj["data"]["createSimulation"]["id"];
                 res.name    = parsed_obj["data"]["createSimulation"]["name"];
-                HelioLogLine(false) << "Helio ← create_simulation status=" << status << " id=" << res.id << " trace=" << res.trace_id;
+                HelioLogLine(false) << "Helio ← create_simulation status=" << status << " id=" << res.id << " trace=" << res.trace_id << " duration=" << req_ms << "ms";
             }
         })
-        .on_error([&res](std::string body, std::string error, unsigned status) {
+        .on_error([&res, &req_start](std::string body, std::string error, unsigned status) {
+            const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
             res.success = false;
             res.error  = error;
             res.status = status;
-            HelioLogLine(true) << "Helio create_simulation error: " << error << " status=" << status;
+            HelioLogLine(true) << "Helio create_simulation error: " << error << " status=" << status << " duration=" << req_ms << "ms" << " body=" << body.substr(0, 300);
         })
         .on_header_callback([&res](std::string header_line) {
             std::string lower_line;
@@ -1762,7 +1805,7 @@ HelioQuery::CheckSimulationProgressResult HelioQuery::check_simulation_progress(
         .on_error([&res](std::string body, std::string error, unsigned status) {
             res.error  = error;
             res.status = status;
-            HelioLogLine(true) << "Helio check_simulation_progress error: " << error << " status=" << status;
+            HelioLogLine(true) << "Helio check_simulation_progress error: " << error << " status=" << status << " body=" << body.substr(0, 300);
         })
         .perform_sync();
 
@@ -1847,7 +1890,8 @@ Slic3r::HelioQuery::CreateOptimizationResult HelioQuery::create_optimization(con
         http.header("Accept-Language", "zh-CN");
     }
 
-    HelioLogLine(false) << "Helio → create_optimization gcode_id=" << gcode_id;
+    HelioLogLine(false) << "Helio → create_optimization gcode_id=" << gcode_id << " url=" << helio_api_url;
+    const auto req_start = std::chrono::steady_clock::now();
     http.timeout_connect(20)
         .timeout_max(100)
         .on_header_callback([&res](std::string header_line) {
@@ -1860,26 +1904,28 @@ Slic3r::HelioQuery::CreateOptimizationResult HelioQuery::create_optimization(con
                 res.trace_id = trace_id;
             }
         })
-        .on_complete([&res](std::string body, unsigned status) {
+        .on_complete([&res, &req_start](std::string body, unsigned status) {
+            const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
             nlohmann::json parsed_obj = nlohmann::json::parse(body);
             res.status                = status;
             if (parsed_obj.contains("errors")) {
                 std::string message = format_error(body);
                 res.error   = message;
                 res.success = false;
-                HelioLogLine(true) << "Helio ← create_optimization status=" << status << " error=" << message << " trace=" << res.trace_id;
+                HelioLogLine(true) << "Helio ← create_optimization status=" << status << " error=" << message << " trace=" << res.trace_id << " duration=" << req_ms << "ms";
             } else {
                 res.success = true;
                 res.id      = parsed_obj["data"]["createOptimization"]["id"];
                 res.name    = parsed_obj["data"]["createOptimization"]["name"];
-                HelioLogLine(false) << "Helio ← create_optimization status=" << status << " id=" << res.id << " trace=" << res.trace_id;
+                HelioLogLine(false) << "Helio ← create_optimization status=" << status << " id=" << res.id << " trace=" << res.trace_id << " duration=" << req_ms << "ms";
             }
         })
-        .on_error([&res](std::string body, std::string error, unsigned status) {
+        .on_error([&res, &req_start](std::string body, std::string error, unsigned status) {
+            const auto req_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - req_start).count();
             res.success = false;
             res.error   = error;
             res.status  = status;
-            HelioLogLine(true) << "Helio create_optimization error: " << error << " status=" << status;
+            HelioLogLine(true) << "Helio create_optimization error: " << error << " status=" << status << " duration=" << req_ms << "ms" << " body=" << body.substr(0, 300);
         })
         .perform_sync();
 
@@ -1995,7 +2041,7 @@ Slic3r::HelioQuery::CheckOptimizationResult HelioQuery::check_optimization_progr
         .on_error([&res](std::string body, std::string error, unsigned status) {
             res.error  = error;
             res.status = status;
-            HelioLogLine(true) << "Helio check_optimization_progress error: " << error << " status=" << status;
+            HelioLogLine(true) << "Helio check_optimization_progress error: " << error << " status=" << status << " body=" << body.substr(0, 300);
         })
         .perform_sync();
 
@@ -2055,11 +2101,11 @@ void HelioBackgroundProcess::clear_helio_file_cache()
             int deleted = boost::nowide::remove(original_path_name.c_str());
 
             if (deleted != 0) {
-                HelioLogLine(true) << "HelioFailed to delete file";
+                HelioLogLine(true) << "Helio Failed to delete file";
             }
         }
         catch (...) {
-            HelioLogLine(true) << "HelioFailed to delete file";
+            HelioLogLine(true) << "Helio Failed to delete file";
         }
     }
 }

--- a/src/slic3r/Utils/HelioDragon.cpp
+++ b/src/slic3r/Utils/HelioDragon.cpp
@@ -27,6 +27,7 @@
 #include <fstream>
 #include <mutex>
 #include <ctime>
+#include <boost/filesystem.hpp>
 
 namespace Slic3r {
 
@@ -43,9 +44,15 @@ void helio_log_write(const std::string& msg, bool is_error)
         BOOST_LOG_TRIVIAL(info) << msg;
 
     static std::mutex mtx;
-    const std::string path = data_dir() + "/log/helio_requests.log";
+    if (data_dir().empty()) return;
+    const boost::filesystem::path log_path =
+        boost::filesystem::path(data_dir()) / "log" / "helio_requests.log";
     std::lock_guard<std::mutex> lk(mtx);
-    std::ofstream f(path, std::ios::app);
+#if defined(_WIN32)
+    std::ofstream f(log_path.wstring(), std::ios::app);
+#else
+    std::ofstream f(log_path.string(), std::ios::app);
+#endif
     if (!f.is_open()) return;
     const auto now = std::chrono::system_clock::now();
     const auto t   = std::chrono::system_clock::to_time_t(now);

--- a/src/slic3r/Utils/HelioDragon.cpp
+++ b/src/slic3r/Utils/HelioDragon.cpp
@@ -133,10 +133,12 @@ void HelioQuery::request_remaining_optimizations(const std::string & helio_api_u
         .header("HelioAdditive-Client-Version", GUI::VersionInfo::convert_full_version(SLIC3R_VERSION))
         .set_post_body(query_body);
 
+    BOOST_LOG_TRIVIAL(info) << "Helio → request_remaining_optimizations " << url_copy;
     http.timeout_connect(20)
         .timeout_max(100)
         .retries(2)
         .on_complete([url_copy, key_copy, func](std::string body, unsigned status) {
+        BOOST_LOG_TRIVIAL(info) << "Helio ← request_remaining_optimizations status=" << status;
         try {
             nlohmann::json parsed_obj = nlohmann::json::parse(body);
 
@@ -227,6 +229,7 @@ void HelioQuery::request_support_machine(const std::string helio_api_url, const 
         .header("HelioAdditive-Client-Version", GUI::VersionInfo::convert_full_version(SLIC3R_VERSION))
         .set_post_body(query_body);
 
+    BOOST_LOG_TRIVIAL(info) << "Helio → request_support_machine page=" << page_copy << " " << url_copy;
     http.timeout_connect(20)
         .timeout_max(100)
         .on_complete([url_copy, key_copy, page_copy, retries_left](std::string body, unsigned status) {
@@ -315,10 +318,11 @@ void HelioQuery::request_support_material(const std::string helio_api_url, const
         .header("HelioAdditive-Client-Version", GUI::VersionInfo::convert_full_version(SLIC3R_VERSION))
         .set_post_body(query_body);
 
+    BOOST_LOG_TRIVIAL(info) << "Helio → request_support_material page=" << page_copy << " " << url_copy;
     http.timeout_connect(20)
         .timeout_max(100)
         .on_complete([url_copy, key_copy, page_copy, retries_left](std::string body, unsigned status) {
-            BOOST_LOG_TRIVIAL(info) << "request_support_material" << body;
+            BOOST_LOG_TRIVIAL(info) << "Helio ← request_support_material page=" << page_copy << " status=" << status;
             nlohmann::json                         parsed_obj = nlohmann::json::parse(body);
             std::vector<HelioQuery::SupportedData> supported_materials;
 
@@ -419,7 +423,7 @@ void HelioQuery::request_print_priority_options(
 
     http.set_post_body(query_body);
 
-    // Use shared_ptr to prevent stack corruption in async callbacks
+    BOOST_LOG_TRIVIAL(info) << "Helio → request_print_priority_options material=" << material_id;
     auto response_headers = std::make_shared<std::string>();
     http.timeout_connect(10)
         .timeout_max(30)
@@ -553,11 +557,13 @@ void HelioQuery::request_pat_token(std::function<void(std::string)> func)
     // DNS hiccups, timeouts, 5xx) via the centralized Http retry loop. HTTP 429
     // "not enough quota" is not retryable — it's classified as a 4xx by the retry
     // logic and propagated to on_error, where we translate it to "not_enough".
+    BOOST_LOG_TRIVIAL(info) << "Helio → request_pat_token " << url_copy;
     auto http = Http::get(url_copy);
     http.timeout_connect(20)
         .timeout_max(100)
         .retries(3)
         .on_complete([func](std::string body, unsigned status) {
+            BOOST_LOG_TRIVIAL(info) << "Helio ← request_pat_token status=" << status;
             if (status == 200) {
                 try {
                     nlohmann::json parsed_obj = nlohmann::json::parse(body);
@@ -617,6 +623,7 @@ void HelioQuery::optimization_feedback(const std::string helio_api_url, const st
         .header("HelioAdditive-Client-Version", GUI::VersionInfo::convert_full_version(SLIC3R_VERSION))
         .set_post_body(query_body);
 
+    BOOST_LOG_TRIVIAL(info) << "Helio → optimization_feedback opt_id=" << optimization_id;
     http.timeout_connect(20)
         .timeout_max(100)
         // One retry only — feedback is a POST and the server has no idempotency key,
@@ -657,6 +664,7 @@ HelioQuery::PresignedURLResult HelioQuery::create_presigned_url(const std::strin
         http.header("Accept-Language", "zh-CN");
     }
 
+    BOOST_LOG_TRIVIAL(info) << "Helio → create_presigned_url " << helio_api_url;
     http.timeout_connect(20)
         .timeout_max(100)
         // create_presigned_url returns an S3 upload URL. Duplicate URLs from a retry
@@ -673,19 +681,22 @@ HelioQuery::PresignedURLResult HelioQuery::create_presigned_url(const std::strin
             }
         })
         .on_complete([&res](std::string body, unsigned status) {
+            res.status = status;
             nlohmann::json parsed_obj = nlohmann::json::parse(body);
-            res.status                = status;
             if (parsed_obj.contains("error")) {
                 res.error = parsed_obj["error"];
+                BOOST_LOG_TRIVIAL(error) << "Helio ← create_presigned_url status=" << status << " error=" << res.error << " trace=" << res.trace_id;
             } else {
                 res.key      = parsed_obj["data"]["getPresignedUrl"]["key"];
                 res.mimeType = parsed_obj["data"]["getPresignedUrl"]["mimeType"];
                 res.url      = parsed_obj["data"]["getPresignedUrl"]["url"];
+                BOOST_LOG_TRIVIAL(info) << "Helio ← create_presigned_url status=" << status << " key=" << res.key << " trace=" << res.trace_id;
             }
         })
         .on_error([&res](std::string body, std::string error, unsigned status) {
             res.error  = (boost::format("error: %1%, message: %2%") % error % body).str();
             res.status = status;
+            BOOST_LOG_TRIVIAL(error) << "Helio create_presigned_url error: " << error << " status=" << status;
         })
         .perform_sync();
 
@@ -717,6 +728,7 @@ HelioQuery::UploadFileResult HelioQuery::upload_file_to_presigned_url(const std:
         BOOST_LOG_TRIVIAL(error) << "Helio upload_file check original: unknown error";
     }
 
+    BOOST_LOG_TRIVIAL(info) << "Helio → upload_file_to_presigned_url file=" << file_path.filename().string();
     http.set_put_body(file_path)
         // S3 PUT against a presigned URL is idempotent: the second PUT just overwrites
         // the first. Two retries gives us resilience for the upload step without
@@ -737,10 +749,12 @@ HelioQuery::UploadFileResult HelioQuery::upload_file_to_presigned_url(const std:
                 res.success = true;
             else
                 res.success = false;
+            BOOST_LOG_TRIVIAL(info) << "Helio ← upload_file_to_presigned_url status=" << status << " success=" << res.success;
         })
         .on_error([&res](std::string body, std::string error, unsigned status) {
             res.success = false;
             res.error   = (boost::format("status: %1%, error: %2%, %3%") % status % body % error).str();
+            BOOST_LOG_TRIVIAL(error) << "Helio upload_file_to_presigned_url error: " << error << " status=" << status;
         })
         .perform_sync();
 
@@ -760,6 +774,7 @@ HelioQuery::PollResult HelioQuery::poll_gcode_status(const std::string& helio_ap
     } )";
     std::string poll_body = (boost::format(poll_query) % gcode_id).str();
 
+    BOOST_LOG_TRIVIAL(debug) << "Helio → poll_gcode_status id=" << gcode_id;
     auto poll_http = Http::post(helio_api_url);
     poll_http.header("Content-Type", "application/json")
         .header("Authorization", helio_api_key)
@@ -904,6 +919,7 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode(const std::string key,
         http.header("Accept-Language", "zh-CN");
     }
 
+    BOOST_LOG_TRIVIAL(info) << "Helio → create_gcode_v2 printer=" << printer_id << " filament=" << filament_id;
     http.timeout_connect(20)
         .timeout_max(100)
         .on_header_callback([&res](std::string header_line) {
@@ -924,6 +940,7 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode(const std::string key,
                 std::string message = format_error(body);
                 res.error = message;
                 res.success = false;
+                BOOST_LOG_TRIVIAL(error) << "Helio ← create_gcode_v2 status=" << status << " error=" << message << " trace=" << res.trace_id;
                 return;
             }
 
@@ -940,6 +957,7 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode(const std::string key,
             res.sizeKb = gcode["sizeKb"];
             res.status_str = gcode["status"];
             res.progress = gcode["progress"];
+            BOOST_LOG_TRIVIAL(info) << "Helio ← create_gcode_v2 status=" << status << " id=" << res.id << " trace=" << res.trace_id;
 
             // Check for errors in initial response
             if (gcode.contains("errors") && !gcode["errors"].is_null()) {
@@ -1057,6 +1075,7 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode(const std::string key,
             res.success = false;
             res.error  = error;
             res.status = status;
+            BOOST_LOG_TRIVIAL(error) << "Helio create_gcode_v2 error: " << error << " status=" << status;
         })
         .perform_sync();
 
@@ -1116,6 +1135,7 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode_v3(const std::string key,
         http.header("Accept-Language", "zh-CN");
     }
 
+    BOOST_LOG_TRIVIAL(info) << "Helio → create_gcode_v3 printer=" << printer_id;
     http.timeout_connect(20)
         .timeout_max(100)
         .on_header_callback([&res](std::string header_line) {
@@ -1136,6 +1156,7 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode_v3(const std::string key,
                 std::string message = format_error(body);
                 res.error = message;
                 res.success = false;
+                BOOST_LOG_TRIVIAL(error) << "Helio ← create_gcode_v3 status=" << status << " error=" << message << " trace=" << res.trace_id;
                 return;
             }
 
@@ -1152,6 +1173,7 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode_v3(const std::string key,
             res.sizeKb = gcode["sizeKb"];
             res.status_str = gcode["status"];
             res.progress = gcode["progress"];
+            BOOST_LOG_TRIVIAL(info) << "Helio ← create_gcode_v3 status=" << status << " id=" << res.id << " trace=" << res.trace_id;
 
             // Check for errors in initial response
             if (gcode.contains("errors") && !gcode["errors"].is_null()) {
@@ -1268,6 +1290,7 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode_v3(const std::string key,
             res.success = false;
             res.error  = error;
             res.status = status;
+            BOOST_LOG_TRIVIAL(error) << "Helio create_gcode_v3 error: " << error << " status=" << status;
         })
         .perform_sync();
 
@@ -1435,6 +1458,7 @@ std::string HelioQuery::create_optimization_default_get(const std::string helio_
         .header("HelioAdditive-Client-Version", GUI::VersionInfo::convert_full_version(SLIC3R_VERSION))
         .set_post_body(query_body);
 
+    BOOST_LOG_TRIVIAL(info) << "Helio → create_optimization_default_get gcode_id=" << gcode_id;
     std::string response_headers;
     http.timeout_connect(20)
         .timeout_max(100)
@@ -1443,6 +1467,7 @@ std::string HelioQuery::create_optimization_default_get(const std::string helio_
             response_headers += headers;
         })
         .on_complete([&res](std::string body, unsigned status) {
+            BOOST_LOG_TRIVIAL(info) << "Helio ← create_optimization_default_get status=" << status;
             nlohmann::json parsed_obj = nlohmann::json::parse(body);
         })
         .on_error([&res, &response_headers](std::string body, std::string error, unsigned status) {
@@ -1493,6 +1518,7 @@ HelioQuery::CreateSimulationResult HelioQuery::create_simulation(const std::stri
         http.header("Accept-Language", "zh-CN");
     }
 
+    BOOST_LOG_TRIVIAL(info) << "Helio → create_simulation gcode_id=" << gcode_id;
     http.timeout_connect(20)
         .timeout_max(100)
         .on_complete([&res](std::string body, unsigned status) {
@@ -1502,16 +1528,19 @@ HelioQuery::CreateSimulationResult HelioQuery::create_simulation(const std::stri
                 std::string message = format_error(body);
                 res.error   = message;
                 res.success = false;
+                BOOST_LOG_TRIVIAL(error) << "Helio ← create_simulation status=" << status << " error=" << message << " trace=" << res.trace_id;
             } else {
                 res.success = true;
                 res.id      = parsed_obj["data"]["createSimulation"]["id"];
                 res.name    = parsed_obj["data"]["createSimulation"]["name"];
+                BOOST_LOG_TRIVIAL(info) << "Helio ← create_simulation status=" << status << " id=" << res.id << " trace=" << res.trace_id;
             }
         })
         .on_error([&res](std::string body, std::string error, unsigned status) {
             res.success = false;
             res.error  = error;
             res.status = status;
+            BOOST_LOG_TRIVIAL(error) << "Helio create_simulation error: " << error << " status=" << status;
         })
         .on_header_callback([&res](std::string header_line) {
             std::string lower_line;
@@ -1595,6 +1624,7 @@ HelioQuery::CheckSimulationProgressResult HelioQuery::check_simulation_progress(
         http.header("Accept-Language", "zh-CN");
     }
 
+    BOOST_LOG_TRIVIAL(debug) << "Helio → check_simulation_progress id=" << simulation_id;
     http.timeout_connect(20)
         .timeout_max(100)
         .retries(2)
@@ -1614,6 +1644,7 @@ HelioQuery::CheckSimulationProgressResult HelioQuery::check_simulation_progress(
             if (parsed_obj.contains("errors")) {
                 std::string message = format_error(body);
                 res.error = message;
+                BOOST_LOG_TRIVIAL(error) << "Helio ← check_simulation_progress status=" << status << " error=" << message;
             } else {
                 if (parsed_obj["data"]["simulation"]["status"] == "FAILED") {
                     res.error = _u8L("Helio simulation task failed");
@@ -1623,6 +1654,7 @@ HelioQuery::CheckSimulationProgressResult HelioQuery::check_simulation_progress(
                 res.name = parsed_obj["data"]["simulation"]["name"];
                 res.progress = parsed_obj["data"]["simulation"]["progress"];
                 res.is_finished = parsed_obj["data"]["simulation"]["status"] == "FINISHED";
+                BOOST_LOG_TRIVIAL(debug) << "Helio ← check_simulation_progress status=" << status << " progress=" << res.progress << " finished=" << res.is_finished;
                 if (res.is_finished) {
                     res.url = parsed_obj["data"]["simulation"]["thermalIndexGcodeUrl"];
                     
@@ -1687,6 +1719,7 @@ HelioQuery::CheckSimulationProgressResult HelioQuery::check_simulation_progress(
         .on_error([&res](std::string body, std::string error, unsigned status) {
             res.error  = error;
             res.status = status;
+            BOOST_LOG_TRIVIAL(error) << "Helio check_simulation_progress error: " << error << " status=" << status;
         })
         .perform_sync();
 
@@ -1771,6 +1804,7 @@ Slic3r::HelioQuery::CreateOptimizationResult HelioQuery::create_optimization(con
         http.header("Accept-Language", "zh-CN");
     }
 
+    BOOST_LOG_TRIVIAL(info) << "Helio → create_optimization gcode_id=" << gcode_id;
     http.timeout_connect(20)
         .timeout_max(100)
         .on_header_callback([&res](std::string header_line) {
@@ -1790,16 +1824,19 @@ Slic3r::HelioQuery::CreateOptimizationResult HelioQuery::create_optimization(con
                 std::string message = format_error(body);
                 res.error   = message;
                 res.success = false;
+                BOOST_LOG_TRIVIAL(error) << "Helio ← create_optimization status=" << status << " error=" << message << " trace=" << res.trace_id;
             } else {
                 res.success = true;
                 res.id      = parsed_obj["data"]["createOptimization"]["id"];
                 res.name    = parsed_obj["data"]["createOptimization"]["name"];
+                BOOST_LOG_TRIVIAL(info) << "Helio ← create_optimization status=" << status << " id=" << res.id << " trace=" << res.trace_id;
             }
         })
         .on_error([&res](std::string body, std::string error, unsigned status) {
             res.success = false;
             res.error   = error;
             res.status  = status;
+            BOOST_LOG_TRIVIAL(error) << "Helio create_optimization error: " << error << " status=" << status;
         })
         .perform_sync();
 
@@ -1873,6 +1910,7 @@ Slic3r::HelioQuery::CheckOptimizationResult HelioQuery::check_optimization_progr
         http.header("Accept-Language", "zh-CN");
     }
 
+    BOOST_LOG_TRIVIAL(debug) << "Helio → check_optimization_progress id=" << optimization_id;
     http.timeout_connect(20)
         .timeout_max(100)
         .retries(2)
@@ -1893,6 +1931,7 @@ Slic3r::HelioQuery::CheckOptimizationResult HelioQuery::check_optimization_progr
             if (parsed_obj.contains("errors")) {
                 std::string message = format_error(body);
                 res.error = message;
+                BOOST_LOG_TRIVIAL(error) << "Helio ← check_optimization_progress status=" << status << " error=" << message;
             } else {
                 if (parsed_obj["data"]["optimization"]["status"] == "FAILED") {
                     res.error = _u8L("Helio optimization task failed");
@@ -1902,6 +1941,7 @@ Slic3r::HelioQuery::CheckOptimizationResult HelioQuery::check_optimization_progr
                 res.name = parsed_obj["data"]["optimization"]["name"];
                 res.progress = parsed_obj["data"]["optimization"]["progress"];
                 res.is_finished = parsed_obj["data"]["optimization"]["status"] == "FINISHED";
+                BOOST_LOG_TRIVIAL(debug) << "Helio ← check_optimization_progress status=" << status << " progress=" << res.progress << " finished=" << res.is_finished;
                 if (res.is_finished) {
                     res.qualityStdImprovement = parsed_obj["data"]["optimization"]["qualityStdImprovement"];
                     res.qualityMeanImprovement = parsed_obj["data"]["optimization"]["qualityMeanImprovement"];
@@ -1912,6 +1952,7 @@ Slic3r::HelioQuery::CheckOptimizationResult HelioQuery::check_optimization_progr
         .on_error([&res](std::string body, std::string error, unsigned status) {
             res.error  = error;
             res.status = status;
+            BOOST_LOG_TRIVIAL(error) << "Helio check_optimization_progress error: " << error << " status=" << status;
         })
         .perform_sync();
 

--- a/src/slic3r/Utils/HelioDragon.cpp
+++ b/src/slic3r/Utils/HelioDragon.cpp
@@ -22,6 +22,8 @@
 #include "wx/app.h"
 #include "cstdio"
 #include <thread>
+#include <chrono>
+#include <memory>
 
 namespace Slic3r {
 
@@ -133,6 +135,7 @@ void HelioQuery::request_remaining_optimizations(const std::string & helio_api_u
 
     http.timeout_connect(20)
         .timeout_max(100)
+        .retries(2)
         .on_complete([url_copy, key_copy, func](std::string body, unsigned status) {
         try {
             nlohmann::json parsed_obj = nlohmann::json::parse(body);
@@ -420,6 +423,7 @@ void HelioQuery::request_print_priority_options(
     auto response_headers = std::make_shared<std::string>();
     http.timeout_connect(10)
         .timeout_max(30)
+        .retries(2)
         .on_header_callback([response_headers](std::string headers) {
             *response_headers += headers;
         })
@@ -545,40 +549,44 @@ void HelioQuery::request_pat_token(std::function<void(std::string)> func)
         url_copy = "https://api.helioadditive.com/rest/auth/anonymous_token/bambustudio";
     }
 
+    // Retry transient transport failures (TLS handshake wobble on Windows/Schannel,
+    // DNS hiccups, timeouts, 5xx) via the centralized Http retry loop. HTTP 429
+    // "not enough quota" is not retryable — it's classified as a 4xx by the retry
+    // logic and propagated to on_error, where we translate it to "not_enough".
     auto http = Http::get(url_copy);
     http.timeout_connect(20)
         .timeout_max(100)
-        .on_complete([url_copy, func](std::string body, unsigned status) {
-            //success
+        .retries(3)
+        .on_complete([func](std::string body, unsigned status) {
             if (status == 200) {
-                nlohmann::json parsed_obj = nlohmann::json::parse(body);
                 try {
+                    nlohmann::json parsed_obj = nlohmann::json::parse(body);
                     if (parsed_obj.contains("pat") && parsed_obj["pat"].is_string()) {
                         func(parsed_obj["pat"].get<std::string>());
-                    }
-                    else {
+                    } else {
                         func("error");
                     }
-
-                }
-                catch (const std::exception& e) {
-                    BOOST_LOG_TRIVIAL(error) << "Helio request_pat_token: " << e.what();
+                } catch (const std::exception &e) {
+                    BOOST_LOG_TRIVIAL(error) << "Helio request_pat_token parse: " << e.what();
+                    func("error");
                 } catch (...) {
-                    BOOST_LOG_TRIVIAL(error) << "Helio request_pat_token: unknown error";
+                    BOOST_LOG_TRIVIAL(error) << "Helio request_pat_token parse: unknown error";
+                    func("error");
                 }
-            }
-            else if (status == 429) {
+            } else if (status == 429) {
                 func("not_enough");
+            } else {
+                func("error");
             }
         })
         .on_error([func](std::string body, std::string error, unsigned status) {
+            BOOST_LOG_TRIVIAL(error) << "Helio request_pat_token error: "
+                                     << error << ", status: " << status;
             if (status == 429) {
                 func("not_enough");
-            }
-            else {
+            } else {
                 func("error");
             }
-            BOOST_LOG_TRIVIAL(error) << "Helio request_pat_token error: " << error << ", status: " << status;
         })
         .perform();
 }
@@ -611,6 +619,10 @@ void HelioQuery::optimization_feedback(const std::string helio_api_url, const st
 
     http.timeout_connect(20)
         .timeout_max(100)
+        // One retry only — feedback is a POST and the server has no idempotency key,
+        // so a retry on a 5xx could create a duplicate feedback record. Transport
+        // errors (the Windows failure mode) are safe because nothing reached the server.
+        .retries(1)
         .on_complete([=](std::string body, unsigned status) {
             BOOST_LOG_TRIVIAL(info) << "optimization_feedback response: " << body << ", status: " << status;
         })
@@ -647,6 +659,9 @@ HelioQuery::PresignedURLResult HelioQuery::create_presigned_url(const std::strin
 
     http.timeout_connect(20)
         .timeout_max(100)
+        // create_presigned_url returns an S3 upload URL. Duplicate URLs from a retry
+        // are harmless — the unused one just expires — so two retries for resilience.
+        .retries(2)
         .on_header_callback([&res](std::string header_line) {
             std::string lower_line;
             for (unsigned char c : header_line) {
@@ -703,6 +718,10 @@ HelioQuery::UploadFileResult HelioQuery::upload_file_to_presigned_url(const std:
     }
 
     http.set_put_body(file_path)
+        // S3 PUT against a presigned URL is idempotent: the second PUT just overwrites
+        // the first. Two retries gives us resilience for the upload step without
+        // creating duplicate server-side state.
+        .retries(2)
         .on_header_callback([&res](std::string header_line) {
             std::string lower_line;
             for (unsigned char c : header_line) {
@@ -747,6 +766,11 @@ HelioQuery::PollResult HelioQuery::poll_gcode_status(const std::string& helio_ap
         .set_post_body(poll_body)
         .timeout_connect(10)
         .timeout_max(30)
+        // Two quiet retries here so a single transient network blip (e.g. a Schannel
+        // revocation-check hiccup or a dropped idle connection on Windows) doesn't
+        // surface as a poll failure to the outer polling loop, which would otherwise
+        // count it toward the consecutive-failure short-circuit budget.
+        .retries(2, 500)
         .on_complete([&result](std::string poll_body, unsigned poll_status) {
             try {
                 json poll_obj = json::parse(poll_body);
@@ -941,53 +965,87 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode(const std::string key,
                 }
             }
 
-            int poll_count = 0;
-            while (res.status_str != "READY" && res.status_str != "ERROR" && res.status_str != "RESTRICTED" && poll_count < 60) {
+            // Poll until terminal state, bounded by wall-clock time. The previous
+            // implementation used a fixed 60-attempt counter: when transient network
+            // errors caused polls to fail fast, the window could be exhausted in seconds
+            // and the user would see "error" even though the server was still computing.
+            //
+            // - kMaxTotalSeconds: overall budget for an optimization result.
+            // - kMaxConsecutiveTransientFailures: short-circuits the wait if we clearly
+            //   lost the network altogether, so the user doesn't stare at a spinner for
+            //   the full budget when nothing is going to change.
+            // - Consecutive-failure counter resets on any successful poll.
+            constexpr int kMaxTotalSeconds = 300;
+            constexpr int kMaxConsecutiveTransientFailures = 10;
+            const auto poll_start = std::chrono::steady_clock::now();
+            int consecutive_failures = 0;
+
+            while (res.status_str != "READY" && res.status_str != "ERROR" && res.status_str != "RESTRICTED") {
                 std::this_thread::sleep_for(std::chrono::seconds(2));
+
+                const auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+                                         std::chrono::steady_clock::now() - poll_start)
+                                         .count();
+                if (elapsed >= kMaxTotalSeconds) {
+                    BOOST_LOG_TRIVIAL(error) << "Helio create_gcode_v2: polling timed out after "
+                                             << elapsed << "s in state " << res.status_str;
+                    res.success = false;
+                    res.error = _u8L("Timed out waiting for optimization result. Please try again.");
+                    return;
+                }
 
                 PollResult poll_res = poll_gcode_status(helio_api_url, helio_api_key, res.id);
 
-                if (poll_res.success) {
-                    res.status_str = poll_res.status_str;
-                    res.progress = poll_res.progress;
-                    res.sizeKb = poll_res.sizeKb;
-
-                    if (!poll_res.errors.empty()) {
-                        std::string error_message;
-                        for (size_t i = 0; i < poll_res.errors.size(); ++i) {
-                            if (poll_res.errors.size() > 1) {
-                                error_message += std::to_string(i + 1) + ". " + poll_res.errors[i];
-                                if (i != poll_res.errors.size() - 1) error_message += "\n";
-                            } else {
-                                error_message = poll_res.errors[i];
-                            }
-                        }
+                if (!poll_res.success) {
+                    consecutive_failures++;
+                    BOOST_LOG_TRIVIAL(warning) << "Helio create_gcode_v2: transient poll failure "
+                                               << consecutive_failures << "/" << kMaxConsecutiveTransientFailures;
+                    if (consecutive_failures >= kMaxConsecutiveTransientFailures) {
                         res.success = false;
-                        res.error = error_message;
+                        res.error = _u8L("Lost connection while waiting for optimization result. Please check your network and try again.");
                         return;
                     }
-
-                    if (res.status_str == "ERROR" || res.status_str == "RESTRICTED") {
-                        res.success = false;
-                        if (res.status_str == "RESTRICTED" && !poll_res.restrictions.empty()) {
-                            std::string restriction_message;
-                            for (size_t i = 0; i < poll_res.restrictions.size(); ++i) {
-                                if (poll_res.restrictions.size() > 1) {
-                                    restriction_message += std::to_string(i + 1) + ". " + poll_res.restrictions[i];
-                                    if (i != poll_res.restrictions.size() - 1) restriction_message += "\n";
-                                } else {
-                                    restriction_message = poll_res.restrictions[i];
-                                }
-                            }
-                            res.error = restriction_message;
-                        } else {
-                            res.error = (boost::format("GCode creation failed with status: %1%") % res.status_str).str();
-                        }
-                        return;
-                    }
+                    continue;
                 }
 
-                poll_count++;
+                consecutive_failures = 0;
+                res.status_str = poll_res.status_str;
+                res.progress = poll_res.progress;
+                res.sizeKb = poll_res.sizeKb;
+
+                if (!poll_res.errors.empty()) {
+                    std::string error_message;
+                    for (size_t i = 0; i < poll_res.errors.size(); ++i) {
+                        if (poll_res.errors.size() > 1) {
+                            error_message += std::to_string(i + 1) + ". " + poll_res.errors[i];
+                            if (i != poll_res.errors.size() - 1) error_message += "\n";
+                        } else {
+                            error_message = poll_res.errors[i];
+                        }
+                    }
+                    res.success = false;
+                    res.error = error_message;
+                    return;
+                }
+
+                if (res.status_str == "ERROR" || res.status_str == "RESTRICTED") {
+                    res.success = false;
+                    if (res.status_str == "RESTRICTED" && !poll_res.restrictions.empty()) {
+                        std::string restriction_message;
+                        for (size_t i = 0; i < poll_res.restrictions.size(); ++i) {
+                            if (poll_res.restrictions.size() > 1) {
+                                restriction_message += std::to_string(i + 1) + ". " + poll_res.restrictions[i];
+                                if (i != poll_res.restrictions.size() - 1) restriction_message += "\n";
+                            } else {
+                                restriction_message = poll_res.restrictions[i];
+                            }
+                        }
+                        res.error = restriction_message;
+                    } else {
+                        res.error = (boost::format("GCode creation failed with status: %1%") % res.status_str).str();
+                    }
+                    return;
+                }
             }
         }
         catch (...) {
@@ -1119,58 +1177,86 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode_v3(const std::string key,
                 }
             }
 
-            int poll_count = 0;
-            while (res.status_str != "READY" && res.status_str != "ERROR" && res.status_str != "RESTRICTED" && poll_count < 60) {
+            // See create_gcode_v2 for the rationale — wall-clock budget with
+            // consecutive-failure short-circuit. Duplicated inline rather than extracted
+            // because the surrounding callback closes over res/helio_api_url/helio_api_key
+            // by reference, and these two helpers share no other structure.
+            constexpr int kMaxTotalSeconds = 300;
+            constexpr int kMaxConsecutiveTransientFailures = 10;
+            const auto poll_start = std::chrono::steady_clock::now();
+            int consecutive_failures = 0;
+
+            while (res.status_str != "READY" && res.status_str != "ERROR" && res.status_str != "RESTRICTED") {
                 std::this_thread::sleep_for(std::chrono::seconds(2));
+
+                const auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+                                         std::chrono::steady_clock::now() - poll_start)
+                                         .count();
+                if (elapsed >= kMaxTotalSeconds) {
+                    BOOST_LOG_TRIVIAL(error) << "Helio create_gcode_v3: polling timed out after "
+                                             << elapsed << "s in state " << res.status_str;
+                    res.success = false;
+                    res.error = _u8L("Timed out waiting for optimization result. Please try again.");
+                    return;
+                }
 
                 PollResult poll_res = poll_gcode_status(helio_api_url, helio_api_key, res.id);
 
-                if (poll_res.success) {
-                    res.status_str = poll_res.status_str;
-                    res.progress = poll_res.progress;
-                    res.sizeKb = poll_res.sizeKb;
-                    
-                    // Check for errors during polling
-                    if (!poll_res.errors.empty()) {
-                        std::string error_message;
-                        for (size_t i = 0; i < poll_res.errors.size(); ++i) {
-                            if (poll_res.errors.size() > 1) {
-                                error_message += std::to_string(i + 1) + ". " + poll_res.errors[i];
-                                if (i != poll_res.errors.size() - 1) {
-                                    error_message += "\n";
-                                }
-                            } else {
-                                error_message = poll_res.errors[i];
-                            }
-                        }
+                if (!poll_res.success) {
+                    consecutive_failures++;
+                    BOOST_LOG_TRIVIAL(warning) << "Helio create_gcode_v3: transient poll failure "
+                                               << consecutive_failures << "/" << kMaxConsecutiveTransientFailures;
+                    if (consecutive_failures >= kMaxConsecutiveTransientFailures) {
                         res.success = false;
-                        res.error = error_message;
+                        res.error = _u8L("Lost connection while waiting for optimization result. Please check your network and try again.");
                         return;
                     }
-                    
-                    // Handle ERROR/RESTRICTED status even if errors array is empty
-                    if (res.status_str == "ERROR" || res.status_str == "RESTRICTED") {
-                        res.success = false;
-                        // For RESTRICTED, use restriction details if available
-                        if (res.status_str == "RESTRICTED" && !poll_res.restrictions.empty()) {
-                            std::string restriction_message;
-                            for (size_t i = 0; i < poll_res.restrictions.size(); ++i) {
-                                if (poll_res.restrictions.size() > 1) {
-                                    restriction_message += std::to_string(i + 1) + ". " + poll_res.restrictions[i];
-                                    if (i != poll_res.restrictions.size() - 1) restriction_message += "\n";
-                                } else {
-                                    restriction_message = poll_res.restrictions[i];
-                                }
-                            }
-                            res.error = restriction_message;
-                        } else {
-                            res.error = (boost::format("GCode creation failed with status: %1%") % res.status_str).str();
-                        }
-                        return;
-                    }
+                    continue;
                 }
 
-                poll_count++;
+                consecutive_failures = 0;
+                res.status_str = poll_res.status_str;
+                res.progress = poll_res.progress;
+                res.sizeKb = poll_res.sizeKb;
+
+                // Check for errors during polling
+                if (!poll_res.errors.empty()) {
+                    std::string error_message;
+                    for (size_t i = 0; i < poll_res.errors.size(); ++i) {
+                        if (poll_res.errors.size() > 1) {
+                            error_message += std::to_string(i + 1) + ". " + poll_res.errors[i];
+                            if (i != poll_res.errors.size() - 1) {
+                                error_message += "\n";
+                            }
+                        } else {
+                            error_message = poll_res.errors[i];
+                        }
+                    }
+                    res.success = false;
+                    res.error = error_message;
+                    return;
+                }
+
+                // Handle ERROR/RESTRICTED status even if errors array is empty
+                if (res.status_str == "ERROR" || res.status_str == "RESTRICTED") {
+                    res.success = false;
+                    // For RESTRICTED, use restriction details if available
+                    if (res.status_str == "RESTRICTED" && !poll_res.restrictions.empty()) {
+                        std::string restriction_message;
+                        for (size_t i = 0; i < poll_res.restrictions.size(); ++i) {
+                            if (poll_res.restrictions.size() > 1) {
+                                restriction_message += std::to_string(i + 1) + ". " + poll_res.restrictions[i];
+                                if (i != poll_res.restrictions.size() - 1) restriction_message += "\n";
+                            } else {
+                                restriction_message = poll_res.restrictions[i];
+                            }
+                        }
+                        res.error = restriction_message;
+                    } else {
+                        res.error = (boost::format("GCode creation failed with status: %1%") % res.status_str).str();
+                    }
+                    return;
+                }
             }
         }
         catch (...) {
@@ -1352,6 +1438,7 @@ std::string HelioQuery::create_optimization_default_get(const std::string helio_
     std::string response_headers;
     http.timeout_connect(20)
         .timeout_max(100)
+        .retries(2)
         .on_header_callback([&response_headers](std::string headers) {
             response_headers += headers;
         })
@@ -1461,6 +1548,8 @@ void HelioQuery::stop_simulation(const std::string helio_api_url, const std::str
 
     http.timeout_connect(20)
         .timeout_max(100)
+        // stop is idempotent — issuing it twice is harmless.
+        .retries(1)
         .on_header_callback([](std::string header_line) {
             std::string lower_line;
             for (unsigned char c : header_line) {
@@ -1508,6 +1597,7 @@ HelioQuery::CheckSimulationProgressResult HelioQuery::check_simulation_progress(
 
     http.timeout_connect(20)
         .timeout_max(100)
+        .retries(2)
         .on_header_callback([&res](std::string header_line) {
             std::string lower_line;
             for (unsigned char c : header_line) {
@@ -1736,6 +1826,8 @@ void HelioQuery::stop_optimization(const std::string helio_api_url, const std::s
 
     http.timeout_connect(20)
         .timeout_max(100)
+        // stop is idempotent — issuing it twice is harmless.
+        .retries(1)
         .on_header_callback([](std::string header_line) {
             std::string lower_line;
             for (unsigned char c : header_line) {
@@ -1783,6 +1875,7 @@ Slic3r::HelioQuery::CheckOptimizationResult HelioQuery::check_optimization_progr
 
     http.timeout_connect(20)
         .timeout_max(100)
+        .retries(2)
         .on_header_callback([&res](std::string header_line) {
             std::string lower_line;
             for (unsigned char c : header_line) {
@@ -2452,6 +2545,7 @@ HelioQuery::GetRecentRunsResult HelioQuery::get_recent_runs(const std::string& h
 
     http.timeout_connect(20)
         .timeout_max(100)
+        .retries(2)
         .on_complete([&temp_optimizations, &temp_simulations, &success, &error_msg, &status_code](std::string body, unsigned status) {
             status_code = status;
 

--- a/src/slic3r/Utils/HelioDragon.cpp
+++ b/src/slic3r/Utils/HelioDragon.cpp
@@ -24,8 +24,51 @@
 #include <thread>
 #include <chrono>
 #include <memory>
+#include <fstream>
+#include <mutex>
+#include <ctime>
 
 namespace Slic3r {
+
+namespace {
+
+// Writes Helio request/response events to a plain-text log that users can share
+// without needing Bambu's decryption infrastructure. Also mirrors to the encrypted
+// boost log so Bambu support can correlate if needed.
+void helio_log_write(const std::string& msg, bool is_error)
+{
+    if (is_error)
+        BOOST_LOG_TRIVIAL(error) << msg;
+    else
+        BOOST_LOG_TRIVIAL(info) << msg;
+
+    static std::mutex mtx;
+    const std::string path = data_dir() + "/log/helio_requests.log";
+    std::lock_guard<std::mutex> lk(mtx);
+    std::ofstream f(path, std::ios::app);
+    if (!f.is_open()) return;
+    const auto now = std::chrono::system_clock::now();
+    const auto t   = std::chrono::system_clock::to_time_t(now);
+    char ts[24];
+    std::strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%SZ", std::gmtime(&t));
+    f << ts << (is_error ? " [ERR] " : " [INF] ") << msg << "\n";
+}
+
+// Stream-style logger that accumulates via << and writes on destruction.
+// Usage: HelioLogLine(false) << "Helio → op " << id;
+// Polling calls skip this and use BOOST_LOG_TRIVIAL(debug) directly to avoid flooding the file.
+struct HelioLogLine {
+    std::ostringstream ss;
+    bool is_error;
+    explicit HelioLogLine(bool err) : is_error(err) {}
+    HelioLogLine(const HelioLogLine&) = delete;
+    HelioLogLine& operator=(const HelioLogLine&) = delete;
+    ~HelioLogLine() { helio_log_write(ss.str(), is_error); }
+    template<typename T>
+    HelioLogLine& operator<<(const T& v) { ss << v; return *this; }
+};
+
+} // anonymous namespace
 
 std::vector<HelioQuery::SupportedData> HelioQuery::global_supported_printers;
 std::vector<HelioQuery::SupportedData> HelioQuery::global_supported_materials;
@@ -133,12 +176,12 @@ void HelioQuery::request_remaining_optimizations(const std::string & helio_api_u
         .header("HelioAdditive-Client-Version", GUI::VersionInfo::convert_full_version(SLIC3R_VERSION))
         .set_post_body(query_body);
 
-    BOOST_LOG_TRIVIAL(info) << "Helio → request_remaining_optimizations " << url_copy;
+    HelioLogLine(false) << "Helio → request_remaining_optimizations " << url_copy;
     http.timeout_connect(20)
         .timeout_max(100)
         .retries(2)
         .on_complete([url_copy, key_copy, func](std::string body, unsigned status) {
-        BOOST_LOG_TRIVIAL(info) << "Helio ← request_remaining_optimizations status=" << status;
+        HelioLogLine(false) << "Helio ← request_remaining_optimizations status=" << status;
         try {
             nlohmann::json parsed_obj = nlohmann::json::parse(body);
 
@@ -193,10 +236,10 @@ void HelioQuery::request_remaining_optimizations(const std::string & helio_api_u
             }
         }
         catch (const std::exception& e) {
-            BOOST_LOG_TRIVIAL(error) << "Helio request_remaining_optimizations: " << e.what();
+            HelioLogLine(true) << "Helio request_remaining_optimizations: " << e.what();
             func(0, 0, "", false, false, false);
         } catch (...) {
-            BOOST_LOG_TRIVIAL(error) << "Helio request_remaining_optimizations: unknown error";
+            HelioLogLine(true) << "Helio request_remaining_optimizations: unknown error";
             func(0, 0, "", false, false, false);
         }
             })
@@ -229,7 +272,7 @@ void HelioQuery::request_support_machine(const std::string helio_api_url, const 
         .header("HelioAdditive-Client-Version", GUI::VersionInfo::convert_full_version(SLIC3R_VERSION))
         .set_post_body(query_body);
 
-    BOOST_LOG_TRIVIAL(info) << "Helio → request_support_machine page=" << page_copy << " " << url_copy;
+    HelioLogLine(false) << "Helio → request_support_machine page=" << page_copy << " " << url_copy;
     http.timeout_connect(20)
         .timeout_max(100)
         .on_complete([url_copy, key_copy, page_copy, retries_left](std::string body, unsigned status) {
@@ -268,7 +311,7 @@ void HelioQuery::request_support_machine(const std::string helio_api_url, const 
                     }
                 }
             } catch (const std::exception& e) {
-                BOOST_LOG_TRIVIAL(error) << "Helio request_support_machine (page " << page_copy << ", retries=" << retries_left << "): " << e.what();
+                HelioLogLine(true) << "Helio request_support_machine (page " << page_copy << ", retries=" << retries_left << "): " << e.what();
                 if (retries_left > 0) {
                     std::this_thread::sleep_for(std::chrono::seconds(2));
                     HelioQuery::request_support_machine(url_copy, key_copy, page_copy, retries_left - 1);
@@ -276,7 +319,7 @@ void HelioQuery::request_support_machine(const std::string helio_api_url, const 
                     HelioQuery::global_printers_fully_loaded = true;
                 }
             } catch (...) {
-                BOOST_LOG_TRIVIAL(error) << "Helio request_support_machine (page " << page_copy << ", retries=" << retries_left << "): unknown error";
+                HelioLogLine(true) << "Helio request_support_machine (page " << page_copy << ", retries=" << retries_left << "): unknown error";
                 if (retries_left > 0) {
                     std::this_thread::sleep_for(std::chrono::seconds(2));
                     HelioQuery::request_support_machine(url_copy, key_copy, page_copy, retries_left - 1);
@@ -318,11 +361,11 @@ void HelioQuery::request_support_material(const std::string helio_api_url, const
         .header("HelioAdditive-Client-Version", GUI::VersionInfo::convert_full_version(SLIC3R_VERSION))
         .set_post_body(query_body);
 
-    BOOST_LOG_TRIVIAL(info) << "Helio → request_support_material page=" << page_copy << " " << url_copy;
+    HelioLogLine(false) << "Helio → request_support_material page=" << page_copy << " " << url_copy;
     http.timeout_connect(20)
         .timeout_max(100)
         .on_complete([url_copy, key_copy, page_copy, retries_left](std::string body, unsigned status) {
-            BOOST_LOG_TRIVIAL(info) << "Helio ← request_support_material page=" << page_copy << " status=" << status;
+            HelioLogLine(false) << "Helio ← request_support_material page=" << page_copy << " status=" << status;
             nlohmann::json                         parsed_obj = nlohmann::json::parse(body);
             std::vector<HelioQuery::SupportedData> supported_materials;
 
@@ -364,7 +407,7 @@ void HelioQuery::request_support_material(const std::string helio_api_url, const
                     }
                 }
             } catch (const std::exception& e) {
-                BOOST_LOG_TRIVIAL(error) << "Helio request_support_material (page " << page_copy << ", retries=" << retries_left << "): " << e.what();
+                HelioLogLine(true) << "Helio request_support_material (page " << page_copy << ", retries=" << retries_left << "): " << e.what();
                 if (retries_left > 0) {
                     std::this_thread::sleep_for(std::chrono::seconds(2));
                     HelioQuery::request_support_material(url_copy, key_copy, page_copy, retries_left - 1);
@@ -372,7 +415,7 @@ void HelioQuery::request_support_material(const std::string helio_api_url, const
                     HelioQuery::global_materials_fully_loaded = true;
                 }
             } catch (...) {
-                BOOST_LOG_TRIVIAL(error) << "Helio request_support_material (page " << page_copy << ", retries=" << retries_left << "): unknown error";
+                HelioLogLine(true) << "Helio request_support_material (page " << page_copy << ", retries=" << retries_left << "): unknown error";
                 if (retries_left > 0) {
                     std::this_thread::sleep_for(std::chrono::seconds(2));
                     HelioQuery::request_support_material(url_copy, key_copy, page_copy, retries_left - 1);
@@ -423,7 +466,7 @@ void HelioQuery::request_print_priority_options(
 
     http.set_post_body(query_body);
 
-    BOOST_LOG_TRIVIAL(info) << "Helio → request_print_priority_options material=" << material_id;
+    HelioLogLine(false) << "Helio → request_print_priority_options material=" << material_id;
     auto response_headers = std::make_shared<std::string>();
     http.timeout_connect(10)
         .timeout_max(30)
@@ -557,13 +600,13 @@ void HelioQuery::request_pat_token(std::function<void(std::string)> func)
     // DNS hiccups, timeouts, 5xx) via the centralized Http retry loop. HTTP 429
     // "not enough quota" is not retryable — it's classified as a 4xx by the retry
     // logic and propagated to on_error, where we translate it to "not_enough".
-    BOOST_LOG_TRIVIAL(info) << "Helio → request_pat_token " << url_copy;
+    HelioLogLine(false) << "Helio → request_pat_token " << url_copy;
     auto http = Http::get(url_copy);
     http.timeout_connect(20)
         .timeout_max(100)
         .retries(3)
         .on_complete([func](std::string body, unsigned status) {
-            BOOST_LOG_TRIVIAL(info) << "Helio ← request_pat_token status=" << status;
+            HelioLogLine(false) << "Helio ← request_pat_token status=" << status;
             if (status == 200) {
                 try {
                     nlohmann::json parsed_obj = nlohmann::json::parse(body);
@@ -573,10 +616,10 @@ void HelioQuery::request_pat_token(std::function<void(std::string)> func)
                         func("error");
                     }
                 } catch (const std::exception &e) {
-                    BOOST_LOG_TRIVIAL(error) << "Helio request_pat_token parse: " << e.what();
+                    HelioLogLine(true) << "Helio request_pat_token parse: " << e.what();
                     func("error");
                 } catch (...) {
-                    BOOST_LOG_TRIVIAL(error) << "Helio request_pat_token parse: unknown error";
+                    HelioLogLine(true) << "Helio request_pat_token parse: unknown error";
                     func("error");
                 }
             } else if (status == 429) {
@@ -586,7 +629,7 @@ void HelioQuery::request_pat_token(std::function<void(std::string)> func)
             }
         })
         .on_error([func](std::string body, std::string error, unsigned status) {
-            BOOST_LOG_TRIVIAL(error) << "Helio request_pat_token error: "
+            HelioLogLine(true) << "Helio request_pat_token error: "
                                      << error << ", status: " << status;
             if (status == 429) {
                 func("not_enough");
@@ -623,7 +666,7 @@ void HelioQuery::optimization_feedback(const std::string helio_api_url, const st
         .header("HelioAdditive-Client-Version", GUI::VersionInfo::convert_full_version(SLIC3R_VERSION))
         .set_post_body(query_body);
 
-    BOOST_LOG_TRIVIAL(info) << "Helio → optimization_feedback opt_id=" << optimization_id;
+    HelioLogLine(false) << "Helio → optimization_feedback opt_id=" << optimization_id;
     http.timeout_connect(20)
         .timeout_max(100)
         // One retry only — feedback is a POST and the server has no idempotency key,
@@ -664,7 +707,7 @@ HelioQuery::PresignedURLResult HelioQuery::create_presigned_url(const std::strin
         http.header("Accept-Language", "zh-CN");
     }
 
-    BOOST_LOG_TRIVIAL(info) << "Helio → create_presigned_url " << helio_api_url;
+    HelioLogLine(false) << "Helio → create_presigned_url " << helio_api_url;
     http.timeout_connect(20)
         .timeout_max(100)
         // create_presigned_url returns an S3 upload URL. Duplicate URLs from a retry
@@ -685,18 +728,18 @@ HelioQuery::PresignedURLResult HelioQuery::create_presigned_url(const std::strin
             nlohmann::json parsed_obj = nlohmann::json::parse(body);
             if (parsed_obj.contains("error")) {
                 res.error = parsed_obj["error"];
-                BOOST_LOG_TRIVIAL(error) << "Helio ← create_presigned_url status=" << status << " error=" << res.error << " trace=" << res.trace_id;
+                HelioLogLine(true) << "Helio ← create_presigned_url status=" << status << " error=" << res.error << " trace=" << res.trace_id;
             } else {
                 res.key      = parsed_obj["data"]["getPresignedUrl"]["key"];
                 res.mimeType = parsed_obj["data"]["getPresignedUrl"]["mimeType"];
                 res.url      = parsed_obj["data"]["getPresignedUrl"]["url"];
-                BOOST_LOG_TRIVIAL(info) << "Helio ← create_presigned_url status=" << status << " key=" << res.key << " trace=" << res.trace_id;
+                HelioLogLine(false) << "Helio ← create_presigned_url status=" << status << " key=" << res.key << " trace=" << res.trace_id;
             }
         })
         .on_error([&res](std::string body, std::string error, unsigned status) {
             res.error  = (boost::format("error: %1%, message: %2%") % error % body).str();
             res.status = status;
-            BOOST_LOG_TRIVIAL(error) << "Helio create_presigned_url error: " << error << " status=" << status;
+            HelioLogLine(true) << "Helio create_presigned_url error: " << error << " status=" << status;
         })
         .perform_sync();
 
@@ -723,12 +766,12 @@ HelioQuery::UploadFileResult HelioQuery::upload_file_to_presigned_url(const std:
         }
     }
     catch (const std::exception& e) {
-        BOOST_LOG_TRIVIAL(error) << "Helio upload_file check original: " << e.what();
+        HelioLogLine(true) << "Helio upload_file check original: " << e.what();
     } catch (...) {
-        BOOST_LOG_TRIVIAL(error) << "Helio upload_file check original: unknown error";
+        HelioLogLine(true) << "Helio upload_file check original: unknown error";
     }
 
-    BOOST_LOG_TRIVIAL(info) << "Helio → upload_file_to_presigned_url file=" << file_path.filename().string();
+    HelioLogLine(false) << "Helio → upload_file_to_presigned_url file=" << file_path.filename().string();
     http.set_put_body(file_path)
         // S3 PUT against a presigned URL is idempotent: the second PUT just overwrites
         // the first. Two retries gives us resilience for the upload step without
@@ -749,12 +792,12 @@ HelioQuery::UploadFileResult HelioQuery::upload_file_to_presigned_url(const std:
                 res.success = true;
             else
                 res.success = false;
-            BOOST_LOG_TRIVIAL(info) << "Helio ← upload_file_to_presigned_url status=" << status << " success=" << res.success;
+            HelioLogLine(false) << "Helio ← upload_file_to_presigned_url status=" << status << " success=" << res.success;
         })
         .on_error([&res](std::string body, std::string error, unsigned status) {
             res.success = false;
             res.error   = (boost::format("status: %1%, error: %2%, %3%") % status % body % error).str();
-            BOOST_LOG_TRIVIAL(error) << "Helio upload_file_to_presigned_url error: " << error << " status=" << status;
+            HelioLogLine(true) << "Helio upload_file_to_presigned_url error: " << error << " status=" << status;
         })
         .perform_sync();
 
@@ -868,13 +911,13 @@ HelioQuery::PollResult HelioQuery::poll_gcode_status(const std::string& helio_ap
                 }
             }
             catch (const std::exception& e) {
-                BOOST_LOG_TRIVIAL(error) << "Helio poll_gcode_status: " << e.what();
+                HelioLogLine(true) << "Helio poll_gcode_status: " << e.what();
             } catch (...) {
-                BOOST_LOG_TRIVIAL(error) << "Helio poll_gcode_status: unknown error";
+                HelioLogLine(true) << "Helio poll_gcode_status: unknown error";
             }
         })
         .on_error([&result](std::string poll_body, std::string poll_error, unsigned poll_status) {
-            BOOST_LOG_TRIVIAL(error) << "Helio poll_gcode_status error: " << poll_error << ", status: " << poll_status;
+            HelioLogLine(true) << "Helio poll_gcode_status error: " << poll_error << ", status: " << poll_status;
         })
         .perform_sync();
 
@@ -919,7 +962,7 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode(const std::string key,
         http.header("Accept-Language", "zh-CN");
     }
 
-    BOOST_LOG_TRIVIAL(info) << "Helio → create_gcode_v2 printer=" << printer_id << " filament=" << filament_id;
+    HelioLogLine(false) << "Helio → create_gcode_v2 printer=" << printer_id << " filament=" << filament_id;
     http.timeout_connect(20)
         .timeout_max(100)
         .on_header_callback([&res](std::string header_line) {
@@ -940,7 +983,7 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode(const std::string key,
                 std::string message = format_error(body);
                 res.error = message;
                 res.success = false;
-                BOOST_LOG_TRIVIAL(error) << "Helio ← create_gcode_v2 status=" << status << " error=" << message << " trace=" << res.trace_id;
+                HelioLogLine(true) << "Helio ← create_gcode_v2 status=" << status << " error=" << message << " trace=" << res.trace_id;
                 return;
             }
 
@@ -957,7 +1000,7 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode(const std::string key,
             res.sizeKb = gcode["sizeKb"];
             res.status_str = gcode["status"];
             res.progress = gcode["progress"];
-            BOOST_LOG_TRIVIAL(info) << "Helio ← create_gcode_v2 status=" << status << " id=" << res.id << " trace=" << res.trace_id;
+            HelioLogLine(false) << "Helio ← create_gcode_v2 status=" << status << " id=" << res.id << " trace=" << res.trace_id;
 
             // Check for errors in initial response
             if (gcode.contains("errors") && !gcode["errors"].is_null()) {
@@ -1005,7 +1048,7 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode(const std::string key,
                                          std::chrono::steady_clock::now() - poll_start)
                                          .count();
                 if (elapsed >= kMaxTotalSeconds) {
-                    BOOST_LOG_TRIVIAL(error) << "Helio create_gcode_v2: polling timed out after "
+                    HelioLogLine(true) << "Helio create_gcode_v2: polling timed out after "
                                              << elapsed << "s in state " << res.status_str;
                     res.success = false;
                     res.error = _u8L("Timed out waiting for optimization result. Please try again.");
@@ -1075,7 +1118,7 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode(const std::string key,
             res.success = false;
             res.error  = error;
             res.status = status;
-            BOOST_LOG_TRIVIAL(error) << "Helio create_gcode_v2 error: " << error << " status=" << status;
+            HelioLogLine(true) << "Helio create_gcode_v2 error: " << error << " status=" << status;
         })
         .perform_sync();
 
@@ -1135,7 +1178,7 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode_v3(const std::string key,
         http.header("Accept-Language", "zh-CN");
     }
 
-    BOOST_LOG_TRIVIAL(info) << "Helio → create_gcode_v3 printer=" << printer_id;
+    HelioLogLine(false) << "Helio → create_gcode_v3 printer=" << printer_id;
     http.timeout_connect(20)
         .timeout_max(100)
         .on_header_callback([&res](std::string header_line) {
@@ -1156,7 +1199,7 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode_v3(const std::string key,
                 std::string message = format_error(body);
                 res.error = message;
                 res.success = false;
-                BOOST_LOG_TRIVIAL(error) << "Helio ← create_gcode_v3 status=" << status << " error=" << message << " trace=" << res.trace_id;
+                HelioLogLine(true) << "Helio ← create_gcode_v3 status=" << status << " error=" << message << " trace=" << res.trace_id;
                 return;
             }
 
@@ -1173,7 +1216,7 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode_v3(const std::string key,
             res.sizeKb = gcode["sizeKb"];
             res.status_str = gcode["status"];
             res.progress = gcode["progress"];
-            BOOST_LOG_TRIVIAL(info) << "Helio ← create_gcode_v3 status=" << status << " id=" << res.id << " trace=" << res.trace_id;
+            HelioLogLine(false) << "Helio ← create_gcode_v3 status=" << status << " id=" << res.id << " trace=" << res.trace_id;
 
             // Check for errors in initial response
             if (gcode.contains("errors") && !gcode["errors"].is_null()) {
@@ -1215,7 +1258,7 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode_v3(const std::string key,
                                          std::chrono::steady_clock::now() - poll_start)
                                          .count();
                 if (elapsed >= kMaxTotalSeconds) {
-                    BOOST_LOG_TRIVIAL(error) << "Helio create_gcode_v3: polling timed out after "
+                    HelioLogLine(true) << "Helio create_gcode_v3: polling timed out after "
                                              << elapsed << "s in state " << res.status_str;
                     res.success = false;
                     res.error = _u8L("Timed out waiting for optimization result. Please try again.");
@@ -1290,7 +1333,7 @@ HelioQuery::CreateGCodeResult HelioQuery::create_gcode_v3(const std::string key,
             res.success = false;
             res.error  = error;
             res.status = status;
-            BOOST_LOG_TRIVIAL(error) << "Helio create_gcode_v3 error: " << error << " status=" << status;
+            HelioLogLine(true) << "Helio create_gcode_v3 error: " << error << " status=" << status;
         })
         .perform_sync();
 
@@ -1458,7 +1501,7 @@ std::string HelioQuery::create_optimization_default_get(const std::string helio_
         .header("HelioAdditive-Client-Version", GUI::VersionInfo::convert_full_version(SLIC3R_VERSION))
         .set_post_body(query_body);
 
-    BOOST_LOG_TRIVIAL(info) << "Helio → create_optimization_default_get gcode_id=" << gcode_id;
+    HelioLogLine(false) << "Helio → create_optimization_default_get gcode_id=" << gcode_id;
     std::string response_headers;
     http.timeout_connect(20)
         .timeout_max(100)
@@ -1467,11 +1510,11 @@ std::string HelioQuery::create_optimization_default_get(const std::string helio_
             response_headers += headers;
         })
         .on_complete([&res](std::string body, unsigned status) {
-            BOOST_LOG_TRIVIAL(info) << "Helio ← create_optimization_default_get status=" << status;
+            HelioLogLine(false) << "Helio ← create_optimization_default_get status=" << status;
             nlohmann::json parsed_obj = nlohmann::json::parse(body);
         })
         .on_error([&res, &response_headers](std::string body, std::string error, unsigned status) {
-            BOOST_LOG_TRIVIAL(error) << "Helio create_optimization_default_get error: " << error << ", status: " << status;
+            HelioLogLine(true) << "Helio create_optimization_default_get error: " << error << ", status: " << status;
         })
         .perform_sync();
 
@@ -1518,7 +1561,7 @@ HelioQuery::CreateSimulationResult HelioQuery::create_simulation(const std::stri
         http.header("Accept-Language", "zh-CN");
     }
 
-    BOOST_LOG_TRIVIAL(info) << "Helio → create_simulation gcode_id=" << gcode_id;
+    HelioLogLine(false) << "Helio → create_simulation gcode_id=" << gcode_id;
     http.timeout_connect(20)
         .timeout_max(100)
         .on_complete([&res](std::string body, unsigned status) {
@@ -1528,19 +1571,19 @@ HelioQuery::CreateSimulationResult HelioQuery::create_simulation(const std::stri
                 std::string message = format_error(body);
                 res.error   = message;
                 res.success = false;
-                BOOST_LOG_TRIVIAL(error) << "Helio ← create_simulation status=" << status << " error=" << message << " trace=" << res.trace_id;
+                HelioLogLine(true) << "Helio ← create_simulation status=" << status << " error=" << message << " trace=" << res.trace_id;
             } else {
                 res.success = true;
                 res.id      = parsed_obj["data"]["createSimulation"]["id"];
                 res.name    = parsed_obj["data"]["createSimulation"]["name"];
-                BOOST_LOG_TRIVIAL(info) << "Helio ← create_simulation status=" << status << " id=" << res.id << " trace=" << res.trace_id;
+                HelioLogLine(false) << "Helio ← create_simulation status=" << status << " id=" << res.id << " trace=" << res.trace_id;
             }
         })
         .on_error([&res](std::string body, std::string error, unsigned status) {
             res.success = false;
             res.error  = error;
             res.status = status;
-            BOOST_LOG_TRIVIAL(error) << "Helio create_simulation error: " << error << " status=" << status;
+            HelioLogLine(true) << "Helio create_simulation error: " << error << " status=" << status;
         })
         .on_header_callback([&res](std::string header_line) {
             std::string lower_line;
@@ -1644,7 +1687,7 @@ HelioQuery::CheckSimulationProgressResult HelioQuery::check_simulation_progress(
             if (parsed_obj.contains("errors")) {
                 std::string message = format_error(body);
                 res.error = message;
-                BOOST_LOG_TRIVIAL(error) << "Helio ← check_simulation_progress status=" << status << " error=" << message;
+                HelioLogLine(true) << "Helio ← check_simulation_progress status=" << status << " error=" << message;
             } else {
                 if (parsed_obj["data"]["simulation"]["status"] == "FAILED") {
                     res.error = _u8L("Helio simulation task failed");
@@ -1719,7 +1762,7 @@ HelioQuery::CheckSimulationProgressResult HelioQuery::check_simulation_progress(
         .on_error([&res](std::string body, std::string error, unsigned status) {
             res.error  = error;
             res.status = status;
-            BOOST_LOG_TRIVIAL(error) << "Helio check_simulation_progress error: " << error << " status=" << status;
+            HelioLogLine(true) << "Helio check_simulation_progress error: " << error << " status=" << status;
         })
         .perform_sync();
 
@@ -1804,7 +1847,7 @@ Slic3r::HelioQuery::CreateOptimizationResult HelioQuery::create_optimization(con
         http.header("Accept-Language", "zh-CN");
     }
 
-    BOOST_LOG_TRIVIAL(info) << "Helio → create_optimization gcode_id=" << gcode_id;
+    HelioLogLine(false) << "Helio → create_optimization gcode_id=" << gcode_id;
     http.timeout_connect(20)
         .timeout_max(100)
         .on_header_callback([&res](std::string header_line) {
@@ -1824,19 +1867,19 @@ Slic3r::HelioQuery::CreateOptimizationResult HelioQuery::create_optimization(con
                 std::string message = format_error(body);
                 res.error   = message;
                 res.success = false;
-                BOOST_LOG_TRIVIAL(error) << "Helio ← create_optimization status=" << status << " error=" << message << " trace=" << res.trace_id;
+                HelioLogLine(true) << "Helio ← create_optimization status=" << status << " error=" << message << " trace=" << res.trace_id;
             } else {
                 res.success = true;
                 res.id      = parsed_obj["data"]["createOptimization"]["id"];
                 res.name    = parsed_obj["data"]["createOptimization"]["name"];
-                BOOST_LOG_TRIVIAL(info) << "Helio ← create_optimization status=" << status << " id=" << res.id << " trace=" << res.trace_id;
+                HelioLogLine(false) << "Helio ← create_optimization status=" << status << " id=" << res.id << " trace=" << res.trace_id;
             }
         })
         .on_error([&res](std::string body, std::string error, unsigned status) {
             res.success = false;
             res.error   = error;
             res.status  = status;
-            BOOST_LOG_TRIVIAL(error) << "Helio create_optimization error: " << error << " status=" << status;
+            HelioLogLine(true) << "Helio create_optimization error: " << error << " status=" << status;
         })
         .perform_sync();
 
@@ -1931,7 +1974,7 @@ Slic3r::HelioQuery::CheckOptimizationResult HelioQuery::check_optimization_progr
             if (parsed_obj.contains("errors")) {
                 std::string message = format_error(body);
                 res.error = message;
-                BOOST_LOG_TRIVIAL(error) << "Helio ← check_optimization_progress status=" << status << " error=" << message;
+                HelioLogLine(true) << "Helio ← check_optimization_progress status=" << status << " error=" << message;
             } else {
                 if (parsed_obj["data"]["optimization"]["status"] == "FAILED") {
                     res.error = _u8L("Helio optimization task failed");
@@ -1952,7 +1995,7 @@ Slic3r::HelioQuery::CheckOptimizationResult HelioQuery::check_optimization_progr
         .on_error([&res](std::string body, std::string error, unsigned status) {
             res.error  = error;
             res.status = status;
-            BOOST_LOG_TRIVIAL(error) << "Helio check_optimization_progress error: " << error << " status=" << status;
+            HelioLogLine(true) << "Helio check_optimization_progress error: " << error << " status=" << status;
         })
         .perform_sync();
 
@@ -2012,11 +2055,11 @@ void HelioBackgroundProcess::clear_helio_file_cache()
             int deleted = boost::nowide::remove(original_path_name.c_str());
 
             if (deleted != 0) {
-                BOOST_LOG_TRIVIAL(error) << "Helio Failed to delete file";
+                HelioLogLine(true) << "HelioFailed to delete file";
             }
         }
         catch (...) {
-            BOOST_LOG_TRIVIAL(error) << "Helio Failed to delete file";
+            HelioLogLine(true) << "HelioFailed to delete file";
         }
     }
 }
@@ -2225,7 +2268,7 @@ void HelioBackgroundProcess::create_simulation_step(HelioQuery::CreateGCodeResul
                     } else {
                         set_state(STATE_CANCELED);
 
-                        BOOST_LOG_TRIVIAL(error) << "Helio simulation progress check returned error: " << check_simulation_progress_res.error;
+                        HelioLogLine(true) << "Helio simulation progress check returned error: " << check_simulation_progress_res.error;
                         
                         std::string error_msg = _u8L("Helio: simulation failed") + "\n" + check_simulation_progress_res.error;
                         Slic3r::HelioCompletionEvent* evt = new Slic3r::HelioCompletionEvent(GUI::EVT_HELIO_PROCESSING_COMPLETED, 0, "", "",
@@ -2255,9 +2298,9 @@ void HelioBackgroundProcess::create_simulation_step(HelioQuery::CreateGCodeResul
                 error = _u8L("Helio: Failed to create Simulation") + "\n" + create_simulation_res.error;
             }
             catch (const std::exception& e) {
-                BOOST_LOG_TRIVIAL(error) << "Helio create_simulation_step format error: " << e.what();
+                HelioLogLine(true) << "Helio create_simulation_step format error: " << e.what();
             } catch (...) {
-                BOOST_LOG_TRIVIAL(error) << "Helio create_simulation_step format error: unknown error";
+                HelioLogLine(true) << "Helio create_simulation_step format error: unknown error";
             }
             
             Slic3r::HelioCompletionEvent* evt = new Slic3r::HelioCompletionEvent(GUI::EVT_HELIO_PROCESSING_COMPLETED, 0, "", "", false, error);
@@ -2272,9 +2315,9 @@ void HelioBackgroundProcess::create_simulation_step(HelioQuery::CreateGCodeResul
             error = _u8L("Helio: Failed to create GCode") + "\n" + create_gcode_res.error;
         }
         catch (const std::exception& e) {
-            BOOST_LOG_TRIVIAL(error) << "Helio create_simulation_step GCode format error: " << e.what();
+            HelioLogLine(true) << "Helio create_simulation_step GCode format error: " << e.what();
         } catch (...) {
-            BOOST_LOG_TRIVIAL(error) << "Helio create_simulation_step GCode format error: unknown error";
+            HelioLogLine(true) << "Helio create_simulation_step GCode format error: unknown error";
         }
 
         Slic3r::HelioCompletionEvent* evt = new Slic3r::HelioCompletionEvent(GUI::EVT_HELIO_PROCESSING_COMPLETED, 0, "", "", false, error);
@@ -2364,7 +2407,7 @@ void HelioBackgroundProcess::create_optimization_step(HelioQuery::CreateGCodeRes
                     else {
                         set_state(STATE_CANCELED);
                         
-                        BOOST_LOG_TRIVIAL(error) << "Helio optimization progress check returned error: " << check_optimzaion_progress_res.error;
+                        HelioLogLine(true) << "Helio optimization progress check returned error: " << check_optimzaion_progress_res.error;
                         
                         std::string error_msg = _u8L("Helio: optimization failed") + "\n" + check_optimzaion_progress_res.error;
                         Slic3r::HelioCompletionEvent* evt = new Slic3r::HelioCompletionEvent(GUI::EVT_HELIO_PROCESSING_COMPLETED, 0, "", "",
@@ -2397,9 +2440,9 @@ void HelioBackgroundProcess::create_optimization_step(HelioQuery::CreateGCodeRes
                 error = _u8L("Helio: Failed to create Optimization") + "\n" + create_optimization_res.error;
             }
             catch (const std::exception& e) {
-                BOOST_LOG_TRIVIAL(error) << "Helio create_optimization_step format error: " << e.what();
+                HelioLogLine(true) << "Helio create_optimization_step format error: " << e.what();
             } catch (...) {
-                BOOST_LOG_TRIVIAL(error) << "Helio create_optimization_step format error: unknown error";
+                HelioLogLine(true) << "Helio create_optimization_step format error: unknown error";
             }
 
             Slic3r::HelioCompletionEvent* evt = new Slic3r::HelioCompletionEvent(GUI::EVT_HELIO_PROCESSING_COMPLETED, 0, "", "", false,
@@ -2416,10 +2459,10 @@ void HelioBackgroundProcess::create_optimization_step(HelioQuery::CreateGCodeRes
             error = _u8L("Helio: Failed to create GCode") + "\n" + create_gcode_res.error;
         }
         catch (const std::exception& e) {
-            BOOST_LOG_TRIVIAL(error) << "Helio create_optimization_step gcode error: " << e.what();
+            HelioLogLine(true) << "Helio create_optimization_step gcode error: " << e.what();
             error = "Helio: Failed to create GCode";
         } catch (...) {
-            BOOST_LOG_TRIVIAL(error) << "Helio create_optimization_step gcode: unknown error";
+            HelioLogLine(true) << "Helio create_optimization_step gcode: unknown error";
             error = "Helio: Failed to create GCode";
         }
 
@@ -2511,10 +2554,10 @@ void HelioBackgroundProcess::save_downloaded_gcode_and_load_preview(std::string 
             error = _u8L("Helio: GCode download failed") + "\n" + response_error;
         }
         catch (const std::exception& e) {
-            BOOST_LOG_TRIVIAL(error) << "Helio gcode download error: " << e.what();
+            HelioLogLine(true) << "Helio gcode download error: " << e.what();
             error = "Helio: GCode download failed";
         } catch (...) {
-            BOOST_LOG_TRIVIAL(error) << "Helio gcode download: unknown error";
+            HelioLogLine(true) << "Helio gcode download: unknown error";
             error = "Helio: GCode download failed";
         }
 

--- a/src/slic3r/Utils/Http.cpp
+++ b/src/slic3r/Utils/Http.cpp
@@ -656,10 +656,9 @@ void Http::priv::http_perform()
 			// We handle HTTP status-code errors separately via the response code branch.
 			case CURLE_HTTP_RETURNED_ERROR:
 			// SSL certificate/verification errors — retrying won't fix a bad cert.
-			case CURLE_PEER_FAILED_VERIFICATION:
+			case CURLE_PEER_FAILED_VERIFICATION: // also covers deprecated CURLE_SSL_CACERT alias
 			case CURLE_SSL_CERTPROBLEM:
 			case CURLE_SSL_CIPHER:
-			case CURLE_SSL_CACERT:
 				return false;
 			// Everything else — DNS failures, connect refusals, TLS handshake failures
 			// (critical on Windows with Schannel), timeouts, partial reads — is retried.

--- a/src/slic3r/Utils/Http.cpp
+++ b/src/slic3r/Utils/Http.cpp
@@ -22,115 +22,9 @@
 #include <openssl/x509.h>
 #endif
 
-#ifdef _WIN32
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-#include <windows.h>
-#include <winhttp.h>
-#endif
-
 namespace fs = boost::filesystem;
 
 namespace Slic3r {
-
-#ifdef _WIN32
-// Query Windows system proxy configuration for a given URL. Returns empty if no proxy
-// should be used, or a string like "http://proxy.corp:8080" otherwise. Handles both
-// static proxy config and WPAD/PAC auto-configuration.
-//
-// Why this exists: libcurl does not consult Windows' IE/WinInet proxy settings. In
-// corporate environments where the browser obeys WPAD/PAC and the registry, curl
-// requests otherwise go direct and get dropped by the perimeter firewall without ever
-// reaching the upstream server.
-static std::string detect_windows_system_proxy(const std::string &url)
-{
-    std::string result;
-
-    WINHTTP_CURRENT_USER_IE_PROXY_CONFIG ie_cfg = {};
-    if (!::WinHttpGetIEProxyConfigForCurrentUser(&ie_cfg)) {
-        return result;
-    }
-
-    auto wide_to_utf8 = [](LPCWSTR wstr) -> std::string {
-        if (!wstr) return std::string();
-        int len = ::WideCharToMultiByte(CP_UTF8, 0, wstr, -1, nullptr, 0, nullptr, nullptr);
-        if (len <= 1) return std::string(); // len includes the null terminator
-        std::string out(static_cast<size_t>(len), '\0');
-        ::WideCharToMultiByte(CP_UTF8, 0, wstr, -1, &out[0], len, nullptr, nullptr);
-        out.resize(static_cast<size_t>(len - 1)); // drop the trailing null from content
-        return out;
-    };
-
-    // Helper: pick the HTTPS proxy out of a possibly-multi-protocol proxy string.
-    // IE proxy strings can be either "host:port" (applies to all) or
-    // "http=host:port;https=host:port;ftp=host:port".
-    auto pick_proxy = [&url](const std::string &proxies) -> std::string {
-        if (proxies.empty()) return std::string();
-        if (proxies.find('=') == std::string::npos) {
-            return proxies;
-        }
-        const bool want_https = (url.rfind("https://", 0) == 0);
-        const std::string key = want_https ? "https=" : "http=";
-        size_t pos = proxies.find(key);
-        if (pos == std::string::npos) return std::string();
-        pos += key.size();
-        size_t end = proxies.find(';', pos);
-        return proxies.substr(pos, end == std::string::npos ? std::string::npos : end - pos);
-    };
-
-    // Case 1: auto-detect (WPAD) or explicit PAC URL — resolve to a concrete proxy.
-    if (ie_cfg.fAutoDetect || ie_cfg.lpszAutoConfigUrl) {
-        HINTERNET session = ::WinHttpOpen(L"BambuStudio/Helio-proxy-detect",
-                                          WINHTTP_ACCESS_TYPE_NO_PROXY,
-                                          WINHTTP_NO_PROXY_NAME,
-                                          WINHTTP_NO_PROXY_BYPASS,
-                                          0);
-        if (session) {
-            WINHTTP_AUTOPROXY_OPTIONS opts = {};
-            if (ie_cfg.fAutoDetect) {
-                opts.dwFlags            = WINHTTP_AUTOPROXY_AUTO_DETECT;
-                opts.dwAutoDetectFlags  = WINHTTP_AUTO_DETECT_TYPE_DHCP | WINHTTP_AUTO_DETECT_TYPE_DNS_A;
-            }
-            if (ie_cfg.lpszAutoConfigUrl) {
-                opts.dwFlags           |= WINHTTP_AUTOPROXY_CONFIG_URL;
-                opts.lpszAutoConfigUrl  = ie_cfg.lpszAutoConfigUrl;
-            }
-            opts.fAutoLogonIfChallenged = TRUE;
-
-            std::wstring wurl(url.begin(), url.end());
-            WINHTTP_PROXY_INFO proxy_info = {};
-            if (::WinHttpGetProxyForUrl(session, wurl.c_str(), &opts, &proxy_info)) {
-                if (proxy_info.dwAccessType == WINHTTP_ACCESS_TYPE_NAMED_PROXY && proxy_info.lpszProxy) {
-                    std::string resolved = wide_to_utf8(proxy_info.lpszProxy);
-                    // WinHttp can return multiple proxies separated by ';' or whitespace; take the first.
-                    size_t sep = resolved.find_first_of("; \t");
-                    if (sep != std::string::npos) resolved = resolved.substr(0, sep);
-                    if (!resolved.empty()) result = resolved;
-                }
-                if (proxy_info.lpszProxy)        ::GlobalFree(proxy_info.lpszProxy);
-                if (proxy_info.lpszProxyBypass)  ::GlobalFree(proxy_info.lpszProxyBypass);
-            }
-            ::WinHttpCloseHandle(session);
-        }
-    }
-
-    // Case 2: static proxy configured in IE/WinInet.
-    if (result.empty() && ie_cfg.lpszProxy) {
-        std::string proxies = wide_to_utf8(ie_cfg.lpszProxy);
-        result = pick_proxy(proxies);
-    }
-
-    if (ie_cfg.lpszProxy)         ::GlobalFree(ie_cfg.lpszProxy);
-    if (ie_cfg.lpszProxyBypass)   ::GlobalFree(ie_cfg.lpszProxyBypass);
-    if (ie_cfg.lpszAutoConfigUrl) ::GlobalFree(ie_cfg.lpszAutoConfigUrl);
-
-    return result;
-}
-#endif // _WIN32
 
 // Private
 
@@ -459,24 +353,6 @@ Http::priv::priv(const std::string &url)
 	::curl_easy_setopt(curl, CURLOPT_BUFFERSIZE, 262144L);
 #ifdef CURLOPT_UPLOAD_BUFFERSIZE
 	::curl_easy_setopt(curl, CURLOPT_UPLOAD_BUFFERSIZE, 262144L);
-#endif
-
-#ifdef _WIN32
-	// Apply Windows system proxy settings. libcurl does not consult WinInet/IE proxy
-	// configuration on its own, so corporate networks that require a proxy for the
-	// browser will drop direct requests from the app without ever reaching the target.
-	{
-		const std::string sys_proxy = detect_windows_system_proxy(url);
-		if (!sys_proxy.empty()) {
-			::curl_easy_setopt(curl, CURLOPT_PROXY, sys_proxy.c_str());
-			// Corporate Windows proxies almost always require NTLM/Negotiate/Kerberos.
-			// CURLAUTH_ANY lets libcurl pick whatever the proxy demands; passing an
-			// empty user:password triggers SSPI so the logged-in user's Windows
-			// credentials are used automatically — same as the browser.
-			::curl_easy_setopt(curl, CURLOPT_PROXYAUTH, (long)CURLAUTH_ANY);
-			::curl_easy_setopt(curl, CURLOPT_PROXYUSERPWD, ":");
-		}
-	}
 #endif
 
 	// Attach the process-global curl_share so DNS resolutions and TLS session tickets

--- a/src/slic3r/Utils/Http.cpp
+++ b/src/slic3r/Utils/Http.cpp
@@ -335,33 +335,6 @@ Http::priv::priv(const std::string &url)
 	// across threads. Harmless on Windows.
 	::curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
 
-	// Enable TCP keepalive so idle connections crossing a NAT/firewall/VPN don't get
-	// silently evicted and leave us blocked waiting on a stale socket. On Windows
-	// especially, split-tunnel VPNs and corporate firewalls drop idle flows fast.
-	::curl_easy_setopt(curl, CURLOPT_TCP_KEEPALIVE, 1L);
-	::curl_easy_setopt(curl, CURLOPT_TCP_KEEPIDLE,  30L);
-	::curl_easy_setopt(curl, CURLOPT_TCP_KEEPINTVL, 15L);
-
-	// Prefer HTTP/2 over TLS when the server advertises it (ALPN-negotiated). Falls
-	// back to HTTP/1.1 transparently. HTTP/2's single-connection-per-origin behavior
-	// combined with the curl_share (see CurlGlobalInit) means repeated polls reuse
-	// the same TCP+TLS connection and amortize the handshake cost.
-	::curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, (long)CURL_HTTP_VERSION_2TLS);
-
-	// Larger recv/send buffers improve throughput on large gcode uploads and reduce
-	// syscall overhead on fast networks. libcurl caps BUFFERSIZE at 512 KiB internally.
-	::curl_easy_setopt(curl, CURLOPT_BUFFERSIZE, 262144L);
-#ifdef CURLOPT_UPLOAD_BUFFERSIZE
-	::curl_easy_setopt(curl, CURLOPT_UPLOAD_BUFFERSIZE, 262144L);
-#endif
-
-	// Attach the process-global curl_share so DNS resolutions and TLS session tickets
-	// are pooled across every Http instance. Each Helio optimization wait makes ~60
-	// polls against the same host; without sharing, each poll is a full TLS handshake
-	// and DNS round-trip. With sharing, polls 2..60 resume the TLS session in 1-RTT.
-	if (CURLSH *share = curl_global_share_handle()) {
-		::curl_easy_setopt(curl, CURLOPT_SHARE, share);
-	}
 }
 
 Http::priv::~priv()

--- a/src/slic3r/Utils/Http.cpp
+++ b/src/slic3r/Utils/Http.cpp
@@ -7,6 +7,9 @@
 #include <mutex>
 #include <sstream>
 #include <exception>
+#include <atomic>
+#include <array>
+#include <chrono>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem.hpp>
@@ -19,9 +22,115 @@
 #include <openssl/x509.h>
 #endif
 
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <winhttp.h>
+#endif
+
 namespace fs = boost::filesystem;
 
 namespace Slic3r {
+
+#ifdef _WIN32
+// Query Windows system proxy configuration for a given URL. Returns empty if no proxy
+// should be used, or a string like "http://proxy.corp:8080" otherwise. Handles both
+// static proxy config and WPAD/PAC auto-configuration.
+//
+// Why this exists: libcurl does not consult Windows' IE/WinInet proxy settings. In
+// corporate environments where the browser obeys WPAD/PAC and the registry, curl
+// requests otherwise go direct and get dropped by the perimeter firewall without ever
+// reaching the upstream server.
+static std::string detect_windows_system_proxy(const std::string &url)
+{
+    std::string result;
+
+    WINHTTP_CURRENT_USER_IE_PROXY_CONFIG ie_cfg = {};
+    if (!::WinHttpGetIEProxyConfigForCurrentUser(&ie_cfg)) {
+        return result;
+    }
+
+    auto wide_to_utf8 = [](LPCWSTR wstr) -> std::string {
+        if (!wstr) return std::string();
+        int len = ::WideCharToMultiByte(CP_UTF8, 0, wstr, -1, nullptr, 0, nullptr, nullptr);
+        if (len <= 1) return std::string(); // len includes the null terminator
+        std::string out(static_cast<size_t>(len), '\0');
+        ::WideCharToMultiByte(CP_UTF8, 0, wstr, -1, &out[0], len, nullptr, nullptr);
+        out.resize(static_cast<size_t>(len - 1)); // drop the trailing null from content
+        return out;
+    };
+
+    // Helper: pick the HTTPS proxy out of a possibly-multi-protocol proxy string.
+    // IE proxy strings can be either "host:port" (applies to all) or
+    // "http=host:port;https=host:port;ftp=host:port".
+    auto pick_proxy = [&url](const std::string &proxies) -> std::string {
+        if (proxies.empty()) return std::string();
+        if (proxies.find('=') == std::string::npos) {
+            return proxies;
+        }
+        const bool want_https = (url.rfind("https://", 0) == 0);
+        const std::string key = want_https ? "https=" : "http=";
+        size_t pos = proxies.find(key);
+        if (pos == std::string::npos) return std::string();
+        pos += key.size();
+        size_t end = proxies.find(';', pos);
+        return proxies.substr(pos, end == std::string::npos ? std::string::npos : end - pos);
+    };
+
+    // Case 1: auto-detect (WPAD) or explicit PAC URL — resolve to a concrete proxy.
+    if (ie_cfg.fAutoDetect || ie_cfg.lpszAutoConfigUrl) {
+        HINTERNET session = ::WinHttpOpen(L"BambuStudio/Helio-proxy-detect",
+                                          WINHTTP_ACCESS_TYPE_NO_PROXY,
+                                          WINHTTP_NO_PROXY_NAME,
+                                          WINHTTP_NO_PROXY_BYPASS,
+                                          0);
+        if (session) {
+            WINHTTP_AUTOPROXY_OPTIONS opts = {};
+            if (ie_cfg.fAutoDetect) {
+                opts.dwFlags            = WINHTTP_AUTOPROXY_AUTO_DETECT;
+                opts.dwAutoDetectFlags  = WINHTTP_AUTO_DETECT_TYPE_DHCP | WINHTTP_AUTO_DETECT_TYPE_DNS_A;
+            }
+            if (ie_cfg.lpszAutoConfigUrl) {
+                opts.dwFlags           |= WINHTTP_AUTOPROXY_CONFIG_URL;
+                opts.lpszAutoConfigUrl  = ie_cfg.lpszAutoConfigUrl;
+            }
+            opts.fAutoLogonIfChallenged = TRUE;
+
+            std::wstring wurl(url.begin(), url.end());
+            WINHTTP_PROXY_INFO proxy_info = {};
+            if (::WinHttpGetProxyForUrl(session, wurl.c_str(), &opts, &proxy_info)) {
+                if (proxy_info.dwAccessType == WINHTTP_ACCESS_TYPE_NAMED_PROXY && proxy_info.lpszProxy) {
+                    std::string resolved = wide_to_utf8(proxy_info.lpszProxy);
+                    // WinHttp can return multiple proxies separated by ';' or whitespace; take the first.
+                    size_t sep = resolved.find_first_of("; \t");
+                    if (sep != std::string::npos) resolved = resolved.substr(0, sep);
+                    if (!resolved.empty()) result = resolved;
+                }
+                if (proxy_info.lpszProxy)        ::GlobalFree(proxy_info.lpszProxy);
+                if (proxy_info.lpszProxyBypass)  ::GlobalFree(proxy_info.lpszProxyBypass);
+            }
+            ::WinHttpCloseHandle(session);
+        }
+    }
+
+    // Case 2: static proxy configured in IE/WinInet.
+    if (result.empty() && ie_cfg.lpszProxy) {
+        std::string proxies = wide_to_utf8(ie_cfg.lpszProxy);
+        result = pick_proxy(proxies);
+    }
+
+    if (ie_cfg.lpszProxy)         ::GlobalFree(ie_cfg.lpszProxy);
+    if (ie_cfg.lpszProxyBypass)   ::GlobalFree(ie_cfg.lpszProxyBypass);
+    if (ie_cfg.lpszAutoConfigUrl) ::GlobalFree(ie_cfg.lpszAutoConfigUrl);
+
+    return result;
+}
+#endif // _WIN32
 
 // Private
 
@@ -29,6 +138,40 @@ struct CurlGlobalInit
 {
     static std::unique_ptr<CurlGlobalInit> instance;
     std::string message;
+
+    // Process-global curl_share object. Lets every curl_easy handle pool its DNS
+    // cache, TLS session tickets, and connection cache, so successive Helio polls
+    // against the same host avoid re-resolving DNS, re-doing a full TLS handshake,
+    // and (where HTTP/2 is available) reuse the existing TCP connection. Crucial
+    // for the optimization-wait polling loop which can fire ~60 requests in 2 min.
+    CURLSH *share = nullptr;
+
+    // One mutex per curl_lock_data enum value (curl serializes access to the shared
+    // caches via the lock/unlock callbacks). CURL_LOCK_DATA_LAST is the sentinel so
+    // sizing by it gives one slot per valid data type.
+    std::array<std::mutex, CURL_LOCK_DATA_LAST> share_mutexes;
+
+    // Number of currently-running http_perform() invocations. Incremented by
+    // Http::perform() before spawning the io_thread, decremented at the top of
+    // http_perform's epilogue. The destructor spin-waits for this to reach zero
+    // so detached io_threads don't race the process shutdown that runs
+    // curl_global_cleanup.
+    std::atomic<int> active_io_threads{0};
+
+    static void share_lock(CURL * /*handle*/, curl_lock_data data, curl_lock_access /*access*/, void *userptr)
+    {
+        auto *self = static_cast<CurlGlobalInit*>(userptr);
+        if (static_cast<size_t>(data) < self->share_mutexes.size()) {
+            self->share_mutexes[data].lock();
+        }
+    }
+    static void share_unlock(CURL * /*handle*/, curl_lock_data data, void *userptr)
+    {
+        auto *self = static_cast<CurlGlobalInit*>(userptr);
+        if (static_cast<size_t>(data) < self->share_mutexes.size()) {
+            self->share_mutexes[data].unlock();
+        }
+    }
 
 	CurlGlobalInit()
     {
@@ -76,13 +219,76 @@ struct CurlGlobalInit
         if (CURLcode ec = ::curl_global_init(CURL_GLOBAL_DEFAULT)) {
             message += "CURL initialization failed. See the log for additional details.";
             BOOST_LOG_TRIVIAL(error) << ::curl_easy_strerror(ec);
+            return;
+        }
+
+        share = ::curl_share_init();
+        if (share != nullptr) {
+            ::curl_share_setopt(share, CURLSHOPT_LOCKFUNC,   share_lock);
+            ::curl_share_setopt(share, CURLSHOPT_UNLOCKFUNC, share_unlock);
+            ::curl_share_setopt(share, CURLSHOPT_USERDATA,   this);
+            ::curl_share_setopt(share, CURLSHOPT_SHARE,      CURL_LOCK_DATA_DNS);
+            ::curl_share_setopt(share, CURLSHOPT_SHARE,      CURL_LOCK_DATA_SSL_SESSION);
+#ifdef CURL_LOCK_DATA_CONNECT
+            // Share the connection cache so handles can pull from the same pool of
+            // live TCP connections. Added in libcurl 7.57.0.
+            ::curl_share_setopt(share, CURLSHOPT_SHARE,      CURL_LOCK_DATA_CONNECT);
+#endif
         }
     }
 
-	~CurlGlobalInit() { ::curl_global_cleanup(); }
+	~CurlGlobalInit()
+    {
+        // Wait for any in-flight io_threads to finish before tearing down libcurl and
+        // the share handle — detached threads would otherwise crash or use-after-free
+        // during global destruction. Bounded by a hard deadline so we never hang the
+        // application on exit even if a thread is genuinely stuck.
+        using namespace std::chrono;
+        const auto deadline = steady_clock::now() + seconds(5);
+        while (active_io_threads.load(std::memory_order_acquire) > 0 &&
+               steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(milliseconds(20));
+        }
+        if (int still_active = active_io_threads.load(std::memory_order_acquire); still_active > 0) {
+            BOOST_LOG_TRIVIAL(warning) << "CurlGlobalInit: shutting down with "
+                                       << still_active << " io_threads still active";
+        }
+
+        if (share != nullptr) {
+            ::curl_share_cleanup(share);
+            share = nullptr;
+        }
+        ::curl_global_cleanup();
+    }
 };
 
 std::unique_ptr<CurlGlobalInit> CurlGlobalInit::instance;
+
+// File-local helper to expose the process-global share handle to priv::priv without
+// leaking a curl-specific type through Http.hpp. Safe to call before CurlGlobalInit
+// has been constructed: returns nullptr and the caller skips CURLOPT_SHARE.
+static CURLSH * curl_global_share_handle()
+{
+    if (CurlGlobalInit::instance) {
+        return CurlGlobalInit::instance->share;
+    }
+    return nullptr;
+}
+
+// File-local helpers for the in-flight io_thread counter used by CurlGlobalInit's
+// destructor to wait for detached threads before tearing down libcurl.
+static void curl_global_io_thread_inc()
+{
+    if (CurlGlobalInit::instance) {
+        CurlGlobalInit::instance->active_io_threads.fetch_add(1, std::memory_order_acq_rel);
+    }
+}
+static void curl_global_io_thread_dec()
+{
+    if (CurlGlobalInit::instance) {
+        CurlGlobalInit::instance->active_io_threads.fetch_sub(1, std::memory_order_acq_rel);
+    }
+}
 
 std::map<std::string, std::string> extra_headers;
 std::mutex g_mutex;
@@ -91,7 +297,11 @@ struct Http::priv
 {
 	enum {
 		DEFAULT_TIMEOUT_CONNECT = 10,
-        DEFAULT_TIMEOUT_MAX = 0,
+        // Overall request timeout in seconds. Previously 0 ("no limit"), which meant a
+        // stuck half-open TCP socket could hang for the OS retransmit budget (~minutes
+        // on Windows) before failing. 120s matches the longest legitimate Helio call
+        // (gcode upload) with a bit of headroom.
+        DEFAULT_TIMEOUT_MAX = 120,
 		DEFAULT_SIZE_LIMIT = 1024 * 1024 * 1024,
 	};
 
@@ -109,7 +319,14 @@ struct Http::priv
 	std::string error_buffer;    // Used for CURLOPT_ERRORBUFFER
     std::string headers;
 	size_t limit;
-	bool cancel;
+	// Must be atomic: Http::cancel() may be called from any thread (typically the UI
+	// thread) while the xfer callback runs on the io_thread that owns this priv.
+	std::atomic<bool> cancel;
+
+	// Retry configuration. 0 (the default) means a single attempt — legacy behavior.
+	// See http_perform() for the classification of retryable failures.
+	int  max_retries            = 0;
+	long retry_initial_backoff_ms = 1000;
 
 	std::thread io_thread;
 	Http::CompleteFn completefn;
@@ -126,6 +343,7 @@ struct Http::priv
 	static int xfercb(void *userp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow);
 	static int xfercb_legacy(void *userp, double dltotal, double dlnow, double ultotal, double ulnow);
 	static size_t form_file_read_cb(char *buffer, size_t size, size_t nitems, void *userp);
+	static int    form_file_seek_cb(void *userp, curl_off_t offset, int origin);
     static size_t headers_cb(char *buffer, size_t size, size_t nitems, void *userp);
 
 	void set_timeout_connect(long timeout);
@@ -144,11 +362,29 @@ struct Http::priv
 	void http_perform();
 };
 
-// add a dummy log callback
-static int log_trace(CURL* handle, curl_infotype type,
-	char* data, size_t size,
-	void* userp)
+// Curl debug callback. By default this is a no-op — curl internally skips most of the
+// expensive formatting when the callback is present but returns 0, so there is no cost.
+// When the environment variable BAMBU_CURL_VERBOSE is set, we route text-class events
+// into the boost log so that user-submitted log bundles can be used to diagnose TLS
+// handshake failures, proxy rejections, and DNS issues that otherwise leave no trace.
+// Data-class events (CURLINFO_*_DATA_*, CURLINFO_*_HEADER_OUT) are skipped so we don't
+// leak request bodies or auth tokens into the log.
+static int log_trace(CURL * /*handle*/, curl_infotype type,
+	char *data, size_t size,
+	void * /*userp*/)
 {
+	static const bool verbose_enabled = (std::getenv("BAMBU_CURL_VERBOSE") != nullptr);
+	if (!verbose_enabled) return 0;
+
+	// Only log text-class events to avoid leaking secrets in headers/bodies.
+	if (type != CURLINFO_TEXT) return 0;
+
+	std::string line(data, size);
+	// Strip the trailing newline curl typically appends.
+	while (!line.empty() && (line.back() == '\n' || line.back() == '\r')) line.pop_back();
+	if (!line.empty()) {
+		BOOST_LOG_TRIVIAL(debug) << "curl: " << line;
+	}
 	return 0;
 }
 
@@ -174,11 +410,82 @@ Http::priv::priv(const std::string &url)
 	::curl_easy_setopt(curl, CURLOPT_URL, url.c_str());   // curl makes a copy internally
 	::curl_easy_setopt(curl, CURLOPT_USERAGENT, SLIC3R_APP_NAME "/" SLIC3R_VERSION);
 	::curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, &error_buffer.front());
-	::curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NATIVE_CA);
-#ifdef __WINDOWS__
-	::curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_MAX_TLSv1_2);
+
+	// SSL options: CURLOPT_SSL_OPTIONS is a bitmask that *replaces* on each setopt call,
+	// so everything must be combined in a single call.
+	//  - CURLSSLOPT_NATIVE_CA: use the OS native CA store (Schannel on Windows, Keychain on
+	//    macOS) rather than bundling our own.
+	//  - CURLSSLOPT_REVOKE_BEST_EFFORT (Windows only, libcurl >= 7.70.0): Schannel does
+	//    *strict* CRL/OCSP revocation by default, which silently fails TLS handshakes when
+	//    revocation endpoints are temporarily unreachable (flaky Wi-Fi, corporate proxies,
+	//    slow CA responders). The browser's Schannel usage is soft-fail, so the browser
+	//    works while our requests disappear before hitting the wire. Best-effort matches
+	//    browser behavior.
+	long ssl_options = CURLSSLOPT_NATIVE_CA;
+#if defined(_WIN32) && defined(CURLSSLOPT_REVOKE_BEST_EFFORT)
+	ssl_options |= CURLSSLOPT_REVOKE_BEST_EFFORT;
 #endif
-	::curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+	::curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, ssl_options);
+
+	// Require at least TLS 1.2 on all platforms, but do not cap the maximum.
+	// Previously this was CURL_SSLVERSION_MAX_TLSv1_2 on Windows, which blocked TLS 1.3
+	// and caused downgrade failures against servers/proxies that expect 1.3.
+	::curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
+
+	// Let the resolver pick IPv4 or IPv6 (Happy Eyeballs). Forcing IPv4 means we cannot
+	// fall back when a host's v4 path is flaky on a given network.
+	::curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_WHATEVER);
+
+	// Required when running libcurl from multiple threads: without this, on POSIX the
+	// async DNS resolver installs a SIGALRM handler and uses siglongjmp, which is unsafe
+	// across threads. Harmless on Windows.
+	::curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+
+	// Enable TCP keepalive so idle connections crossing a NAT/firewall/VPN don't get
+	// silently evicted and leave us blocked waiting on a stale socket. On Windows
+	// especially, split-tunnel VPNs and corporate firewalls drop idle flows fast.
+	::curl_easy_setopt(curl, CURLOPT_TCP_KEEPALIVE, 1L);
+	::curl_easy_setopt(curl, CURLOPT_TCP_KEEPIDLE,  30L);
+	::curl_easy_setopt(curl, CURLOPT_TCP_KEEPINTVL, 15L);
+
+	// Prefer HTTP/2 over TLS when the server advertises it (ALPN-negotiated). Falls
+	// back to HTTP/1.1 transparently. HTTP/2's single-connection-per-origin behavior
+	// combined with the curl_share (see CurlGlobalInit) means repeated polls reuse
+	// the same TCP+TLS connection and amortize the handshake cost.
+	::curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, (long)CURL_HTTP_VERSION_2TLS);
+
+	// Larger recv/send buffers improve throughput on large gcode uploads and reduce
+	// syscall overhead on fast networks. libcurl caps BUFFERSIZE at 512 KiB internally.
+	::curl_easy_setopt(curl, CURLOPT_BUFFERSIZE, 262144L);
+#ifdef CURLOPT_UPLOAD_BUFFERSIZE
+	::curl_easy_setopt(curl, CURLOPT_UPLOAD_BUFFERSIZE, 262144L);
+#endif
+
+#ifdef _WIN32
+	// Apply Windows system proxy settings. libcurl does not consult WinInet/IE proxy
+	// configuration on its own, so corporate networks that require a proxy for the
+	// browser will drop direct requests from the app without ever reaching the target.
+	{
+		const std::string sys_proxy = detect_windows_system_proxy(url);
+		if (!sys_proxy.empty()) {
+			::curl_easy_setopt(curl, CURLOPT_PROXY, sys_proxy.c_str());
+			// Corporate Windows proxies almost always require NTLM/Negotiate/Kerberos.
+			// CURLAUTH_ANY lets libcurl pick whatever the proxy demands; passing an
+			// empty user:password triggers SSPI so the logged-in user's Windows
+			// credentials are used automatically — same as the browser.
+			::curl_easy_setopt(curl, CURLOPT_PROXYAUTH, (long)CURLAUTH_ANY);
+			::curl_easy_setopt(curl, CURLOPT_PROXYUSERPWD, ":");
+		}
+	}
+#endif
+
+	// Attach the process-global curl_share so DNS resolutions and TLS session tickets
+	// are pooled across every Http instance. Each Helio optimization wait makes ~60
+	// polls against the same host; without sharing, each poll is a full TLS handshake
+	// and DNS round-trip. With sharing, polls 2..60 resume the TLS session in 1-RTT.
+	if (CURLSH *share = curl_global_share_handle()) {
+		::curl_easy_setopt(curl, CURLOPT_SHARE, share);
+	}
 }
 
 Http::priv::~priv()
@@ -229,7 +536,9 @@ size_t Http::priv::writecb(void *data, size_t size, size_t nmemb, void *userp)
 int Http::priv::xfercb(void *userp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow)
 {
 	auto self = static_cast<priv*>(userp);
-	bool cb_cancel = false;
+	// Snapshot the external cancel flag early so a race doesn't give the progressfn a
+	// stale view of whether it still needs to compute.
+	bool cb_cancel = self->cancel.load(std::memory_order_acquire);
 
 	if (self->progressfn) {
 		double speed;
@@ -240,9 +549,11 @@ int Http::priv::xfercb(void *userp, curl_off_t dltotal, curl_off_t dlnow, curl_o
 		self->progressfn(progress, cb_cancel);
 	}
 
-	if (cb_cancel) { self->cancel = true; }
+	if (cb_cancel) { self->cancel.store(true, std::memory_order_release); }
 
-	return self->cancel;
+	// Returning non-zero from CURLOPT_XFERINFOFUNCTION aborts the transfer with
+	// CURLE_ABORTED_BY_CALLBACK.
+	return self->cancel.load(std::memory_order_acquire) ? 1 : 0;
 }
 
 int Http::priv::xfercb_legacy(void *userp, double dltotal, double dlnow, double ultotal, double ulnow)
@@ -264,6 +575,35 @@ size_t Http::priv::form_file_read_cb(char *buffer, size_t size, size_t nitems, v
 	}
 
 	return CURL_READFUNC_ABORT;
+}
+
+// Seek callback paired with form_file_read_cb. Required for any retry or follow-redirect
+// path that re-issues the same PUT — without it, curl cannot rewind the upload stream
+// and the second attempt would send an empty body. Returns CURL_SEEKFUNC_OK on success,
+// CURL_SEEKFUNC_CANTSEEK to tell curl the stream is not rewindable (which would force it
+// to bail with CURLE_SEND_FAIL_REWIND on the retry).
+int Http::priv::form_file_seek_cb(void *userp, curl_off_t offset, int origin)
+{
+	try {
+		auto fstream = static_cast<fs::ifstream *>(userp);
+		if (!fstream) { return CURL_SEEKFUNC_FAIL; }
+
+		std::ios_base::seekdir dir = std::ios_base::beg;
+		switch (origin) {
+			case SEEK_SET: dir = std::ios_base::beg; break;
+			case SEEK_CUR: dir = std::ios_base::cur; break;
+			case SEEK_END: dir = std::ios_base::end; break;
+			default: return CURL_SEEKFUNC_FAIL;
+		}
+
+		// Clear any EOF/fail bits before seeking — after a full read, the stream is
+		// in eof()==true and subsequent read() calls return 0 bytes until state clears.
+		fstream->clear();
+		fstream->seekg(static_cast<std::streamoff>(offset), dir);
+		return fstream->good() ? CURL_SEEKFUNC_OK : CURL_SEEKFUNC_CANTSEEK;
+	} catch (const std::exception &) {
+		return CURL_SEEKFUNC_FAIL;
+	}
 }
 
 size_t Http::priv::headers_cb(char *buffer, size_t size, size_t nitems, void *userp)
@@ -365,6 +705,11 @@ void Http::priv::set_put_body(const fs::path &path)
 		::curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
 		::curl_easy_setopt(curl, CURLOPT_READDATA, static_cast<void*>(&putFile));
 		::curl_easy_setopt(curl, CURLOPT_INFILESIZE, filesize);
+		// Seek callback so the retry loop (see http_perform) can rewind the file
+		// between attempts. Without this, a retried PUT would send a zero-byte body
+		// because the ifstream is left at EOF after the first pass.
+		::curl_easy_setopt(curl, CURLOPT_SEEKFUNCTION, form_file_seek_cb);
+		::curl_easy_setopt(curl, CURLOPT_SEEKDATA, static_cast<void*>(&putFile));
 	}
 }
 
@@ -429,14 +774,103 @@ void Http::priv::http_perform()
 		::curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, postfields.size());
 	}
 
-	CURLcode res = ::curl_easy_perform(curl);
+	// Classification helpers for the retry loop. The broad rule: retry anything that
+	// could plausibly succeed on a second attempt against the same URL with the same
+	// inputs, and never retry anything where re-issuing is either pointless or unsafe.
+	auto is_retryable_curl_error = [](CURLcode code) -> bool {
+		switch (code) {
+			// User-driven or programmatic cancellation — never retry.
+			case CURLE_ABORTED_BY_CALLBACK:
+			// Size-limit abort from the write callback — never retry.
+			case CURLE_WRITE_ERROR:
+			// Programmer error — retry will not help.
+			case CURLE_UNSUPPORTED_PROTOCOL:
+			case CURLE_FAILED_INIT:
+			case CURLE_URL_MALFORMAT:
+			case CURLE_NOT_BUILT_IN:
+			case CURLE_FUNCTION_NOT_FOUND:
+			case CURLE_BAD_FUNCTION_ARGUMENT:
+			case CURLE_UNKNOWN_OPTION:
+			// Auth failures — credentials are not going to repair themselves.
+			case CURLE_LOGIN_DENIED:
+			case CURLE_AUTH_ERROR:
+			case CURLE_REMOTE_ACCESS_DENIED:
+			// We handle HTTP status-code errors separately via the response code branch.
+			case CURLE_HTTP_RETURNED_ERROR:
+				return false;
+			// Everything else — DNS failures, connect refusals, TLS handshake failures
+			// (critical on Windows with Schannel), timeouts, partial reads — is retried.
+			default:
+				return true;
+		}
+	};
+	auto is_retryable_http_status = [](long status) -> bool {
+		if (status == 408 || status == 425) return true;              // Request Timeout / Too Early
+		if (status >= 500 && status <= 599 && status != 501) return true; // 5xx except Not Implemented
+		return false;
+	};
+
+	const int total_attempts = std::max(1, max_retries + 1);
+	CURLcode res             = CURLE_OK;
+	long     http_status     = 0;
+
+	for (int attempt = 0; attempt < total_attempts; ++attempt) {
+		if (attempt > 0) {
+			// Exponential backoff with a 30s ceiling per attempt. The cap matters for
+			// callers that bumped retry count high — without it, 6 retries at 1s base
+			// would wait 63 seconds on the final backoff alone.
+			long delay_ms = retry_initial_backoff_ms * (1L << (attempt - 1));
+			if (delay_ms > 30000) delay_ms = 30000;
+
+			// Sleep in short chunks so Http::cancel() can abort a long backoff. Without
+			// this, a user who clicks Cancel during a retry backoff would wait up to
+			// 30s before anything happened.
+			const long chunk_ms   = 200;
+			long       remaining  = delay_ms;
+			while (remaining > 0 && !cancel.load(std::memory_order_acquire)) {
+				const long this_chunk = remaining > chunk_ms ? chunk_ms : remaining;
+				std::this_thread::sleep_for(std::chrono::milliseconds(this_chunk));
+				remaining -= this_chunk;
+			}
+			if (cancel.load(std::memory_order_acquire)) {
+				res = CURLE_ABORTED_BY_CALLBACK;
+				break;
+			}
+
+			// Reset per-attempt state. curl itself reuses the handle happily, but we
+			// need to clear the buffers we own so the second attempt doesn't append
+			// to a partially-filled buffer from the first.
+			buffer.clear();
+			headers.clear();
+			if (!error_buffer.empty()) {
+				std::fill(error_buffer.begin(), error_buffer.end(), '\0');
+			}
+
+			BOOST_LOG_TRIVIAL(info) << "Http: retrying after transient failure, attempt "
+			                        << (attempt + 1) << "/" << total_attempts;
+		}
+
+		res         = ::curl_easy_perform(curl);
+		http_status = 0;
+
+		if (res == CURLE_OK) {
+			::curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_status);
+			if (http_status >= 200 && http_status < 300) break;       // success
+			if (!is_retryable_http_status(http_status)) break;        // permanent HTTP error
+		} else {
+			if (!is_retryable_curl_error(res)) break;                 // permanent transport error
+		}
+		// Otherwise fall through to the next iteration of the retry loop.
+	}
+
+	// Final dispatch to user callbacks. This runs exactly once per http_perform call.
 	if (res != CURLE_OK) {
 		if (res == CURLE_ABORTED_BY_CALLBACK) {
-			if (cancel) {
+			if (cancel.load(std::memory_order_acquire)) {
 				// The abort comes from the request being cancelled programatically
 				Progress dummyprogress(0, 0, 0, 0);
-				bool cancel = true;
-				if (progressfn) { progressfn(dummyprogress, cancel); }
+				bool cancel_flag = true;
+				if (progressfn) { progressfn(dummyprogress, cancel_flag); }
 			} else {
 				// The abort comes from the CURLOPT_READFUNCTION callback, which means reading file failed
 				if (errorfn) { errorfn(std::move(buffer), "Error reading file for file upload", 0); }
@@ -448,9 +882,6 @@ void Http::priv::http_perform()
 			if (errorfn) { errorfn(std::move(buffer), curl_error(res), 0); }
 		};
 	} else {
-		long http_status = 0;
-		::curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_status);
-
 		//BBS check success http status code
 		if (http_status >= 200 && http_status < 300) {
 			if (completefn) { completefn(std::move(buffer), http_status); }
@@ -506,6 +937,15 @@ Http& Http::timeout_max(long timeout)
 Http& Http::size_limit(size_t sizeLimit)
 {
 	if (p) { p->limit = sizeLimit; }
+	return *this;
+}
+
+Http& Http::retries(int retry_count, long initial_backoff_ms)
+{
+	if (p) {
+		p->max_retries             = (retry_count < 0) ? 0 : retry_count;
+		p->retry_initial_backoff_ms = (initial_backoff_ms < 0) ? 0 : initial_backoff_ms;
+	}
 	return *this;
 }
 
@@ -680,8 +1120,19 @@ Http::Ptr Http::perform()
 	auto self = std::make_shared<Http>(std::move(*this));
 
 	if (self->p) {
+		// Increment the in-flight counter *before* spawning the thread so
+		// CurlGlobalInit's destructor can never observe a moment where the thread
+		// exists but the counter hasn't been bumped yet. The wrapper lambda
+		// guarantees the matching decrement even if http_perform throws.
+		curl_global_io_thread_inc();
 		auto io_thread = std::thread([self](){
-				self->p->http_perform();
+				try {
+					self->p->http_perform();
+				} catch (...) {
+					curl_global_io_thread_dec();
+					throw;
+				}
+				curl_global_io_thread_dec();
 			});
 		self->p->io_thread = std::move(io_thread);
 	}
@@ -691,12 +1142,28 @@ Http::Ptr Http::perform()
 
 void Http::perform_sync()
 {
-	if (p) { p->http_perform(); }
+	if (p) {
+		// Synchronous execution runs on the caller's thread, so no detached thread
+		// to track — but we still wrap the counter for consistency and so that a
+		// shutdown initiated from another thread while a sync request is in flight
+		// waits for it to finish.
+		curl_global_io_thread_inc();
+		try {
+			p->http_perform();
+		} catch (...) {
+			curl_global_io_thread_dec();
+			throw;
+		}
+		curl_global_io_thread_dec();
+	}
 }
 
 void Http::cancel()
 {
-	if (p) { p->cancel = true; }
+	// May be called from any thread (typically the UI thread). The xfer callback
+	// running on the io_thread reads this and aborts curl_easy_perform by returning
+	// non-zero from CURLOPT_XFERINFOFUNCTION.
+	if (p) { p->cancel.store(true, std::memory_order_release); }
 }
 
 Http Http::get(std::string url)

--- a/src/slic3r/Utils/Http.cpp
+++ b/src/slic3r/Utils/Http.cpp
@@ -321,10 +321,17 @@ Http::priv::priv(const std::string &url)
 #endif
 	::curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, ssl_options);
 
-	// Require at least TLS 1.2 on all platforms, but do not cap the maximum.
-	// Previously this was CURL_SSLVERSION_MAX_TLSv1_2 on Windows, which blocked TLS 1.3
-	// and caused downgrade failures against servers/proxies that expect 1.3.
+	// Require at least TLS 1.2 on all platforms. On Windows we additionally cap the
+	// maximum at TLS 1.2 (TEST C: bisecting a regression where Helio traffic leaves
+	// the Bambu printer camera unable to connect afterward on Windows only). Schannel
+	// TLS 1.3 session state may be interfering with the closed-source Bambu network
+	// plugin's subsequent Schannel usage; revert matches the original pre-133450fee
+	// behavior on Windows while leaving macOS/Linux free to negotiate TLS 1.3.
+#ifdef __WINDOWS__
+	::curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_TLSv1_2);
+#else
 	::curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
+#endif
 
 	// Let the resolver pick IPv4 or IPv6 (Happy Eyeballs). Forcing IPv4 means we cannot
 	// fall back when a host's v4 path is flaky on a given network.

--- a/src/slic3r/Utils/Http.cpp
+++ b/src/slic3r/Utils/Http.cpp
@@ -301,6 +301,8 @@ Http::priv::priv(const std::string &url)
 	set_timeout_connect(DEFAULT_TIMEOUT_CONNECT);
     set_timeout_max(DEFAULT_TIMEOUT_MAX);
 	::curl_easy_setopt(curl, CURLOPT_DEBUGFUNCTION, log_trace);
+	if (CURLSH *sh = curl_global_share_handle())
+		::curl_easy_setopt(curl, CURLOPT_SHARE, sh);
 	::curl_easy_setopt(curl, CURLOPT_URL, url.c_str());   // curl makes a copy internally
 	::curl_easy_setopt(curl, CURLOPT_USERAGENT, SLIC3R_APP_NAME "/" SLIC3R_VERSION);
 	::curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, &error_buffer.front());
@@ -653,6 +655,11 @@ void Http::priv::http_perform()
 			case CURLE_REMOTE_ACCESS_DENIED:
 			// We handle HTTP status-code errors separately via the response code branch.
 			case CURLE_HTTP_RETURNED_ERROR:
+			// SSL certificate/verification errors — retrying won't fix a bad cert.
+			case CURLE_PEER_FAILED_VERIFICATION:
+			case CURLE_SSL_CERTPROBLEM:
+			case CURLE_SSL_CIPHER:
+			case CURLE_SSL_CACERT:
 				return false;
 			// Everything else — DNS failures, connect refusals, TLS handshake failures
 			// (critical on Windows with Schannel), timeouts, partial reads — is retried.

--- a/src/slic3r/Utils/Http.hpp
+++ b/src/slic3r/Utils/Http.hpp
@@ -104,6 +104,18 @@ public:
 	// Sets a maximum size of the data that can be received.
 	// A value of zero sets the default limit, which is is 5MB.
 	Http& size_limit(size_t sizeLimit);
+	// Enable automatic retry on transient transport failures and retryable HTTP statuses.
+	//
+	//   retry_count           - number of extra attempts after the first (so 3 = up to 4 total requests)
+	//   initial_backoff_ms    - first backoff delay, doubles each subsequent retry (capped at 30s)
+	//
+	// Retryable: DNS failure, connect failure, TLS handshake failure (critical on Windows
+	// with Schannel), timeouts, partial reads, 5xx except 501, 408 Request Timeout, 425
+	// Too Early. Never retried: 4xx client errors (including 429), user cancellation,
+	// size-limit aborts, malformed URLs, auth failures. Use this in preference to
+	// per-callsite retry loops — the retry happens inside the same io_thread without
+	// stacking additional std::thread creations per attempt.
+	Http& retries(int retry_count, long initial_backoff_ms = 1000);
 	// Sets a HTTP header field.
 	Http& header(std::string name, const std::string &value);
 	// Removes a header field.


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed configurable automatic retry/backoff for network requests.
  * Added a Helio connectivity test (ping + presigned-url check) to Network Test.

* **Bug Fixes**
  * Replaced fixed poll-counts with wall-clock timeouts and consecutive-transient-failure detection to surface “lost connection”/timeout errors.
  * Retries support rewindable uploads and single consistent completion callbacks.
  * Shutdown now waits briefly for in-flight network work; default request timeout bounded.

* **Security/Performance**
  * Stronger TLS requirement and connection sharing to improve security and network efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces ad-hoc Helio networking with a centralised retry/backoff infrastructure in `Http`, adds a global curl share handle for DNS/TLS/connection reuse, switches polling loops from fixed-count to wall-clock timeouts with consecutive-failure detection, and exposes a Helio connectivity test in the Network Test dialog.

- `Http.cpp` gains a retry loop with exponential backoff, an atomic cancel flag, a PUT seek callback for rewindable uploads, `CURLOPT_NOSIGNAL` for multi-thread safety, and a 120s default request timeout.
- `HelioDragon.cpp` adds `HelioLogLine` structured per-request logging and per-call `.retries()` annotations; `optimization_feedback` adds `.retries(1)` but the retry logic includes HTTP 5xx responses, contradicting the inline comment that only transport errors are safe to replay on this non-idempotent POST.
- `NetworkTestDialog` unhides the Export Log button and adds a Helio-Additive ping + presigned-URL smoke test.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one fix: optimization_feedback must not re-issue the POST on HTTP 5xx responses.

The retry infrastructure and poll-loop refactor are well-constructed. One concrete defect: optimization_feedback adds .retries(1) but is_retryable_http_status classifies 5xx as retryable, meaning a server-received POST can be retried and produce a duplicate feedback record — the exact outcome the inline comment says to avoid.

src/slic3r/Utils/HelioDragon.cpp — specifically the optimization_feedback retry call

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/slic3r/Utils/Http.cpp | Core HTTP infrastructure overhaul: exponential-backoff retry loop, global curl share handle, atomic cancel flag, PUT seek callback, CURLOPT_NOSIGNAL, bounded shutdown wait, DEFAULT_TIMEOUT_MAX raised from 0 to 120s. |
| src/slic3r/Utils/HelioDragon.cpp | Adds HelioLogLine structured logging, per-request timing, and .retries() calls throughout; replaces fixed poll-count loops with wall-clock timeout. optimization_feedback incorrectly retries on 5xx; dead 429 branch in request_pat_token on_complete. |
| src/slic3r/GUI/NetworkTestDialog.cpp | Adds Helio-Additive connectivity test and unhides the Export Log button with a log-directory handler. |
| src/slic3r/GUI/NetworkTestDialog.hpp | Adds TEST_HELIO_PING_JOB (9), bumps TEST_JOB_MAX to 10, declares new UI members and test methods. |
| src/slic3r/Utils/Http.hpp | Exposes Http::retries(count, initial_backoff_ms) with documentation of retryable vs non-retryable failure categories. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as UI Thread
    participant HD as HelioDragon
    participant HP as Http::perform[Sync]
    participant RL as Retry Loop
    participant SV as Helio Server / S3

    UI->>HD: create_gcode / upload / PAT
    HD->>HP: .retries(N).perform_sync()
    HP->>RL: attempt 1
    RL->>SV: curl_easy_perform
    SV-->>RL: 5xx / CURL error
    RL->>RL: backoff (exponential, max 30s)
    RL->>SV: attempt 2
    SV-->>RL: 200 OK
    RL-->>HP: break (success)
    HP->>HD: on_complete(body, status)
    HD->>HD: poll_gcode_status loop (wall-clock 300s)
    HD-->>UI: result callback
```

<sub>Reviews (3): Last reviewed commit: ["Update http.cpp"](https://github.com/helio-additive/bambustudio/commit/091e5bac86aaef3969bbccf7e9509c10026e543e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32740200)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->